### PR TITLE
This is the last commit needed to build with REDIS

### DIFF
--- a/src/output_modules/output_modules.c
+++ b/src/output_modules/output_modules.c
@@ -18,7 +18,6 @@ extern output_module_t module_extended_file;
 
 #ifdef REDIS
 extern output_module_t module_redis;
-extern output_module_t module_ssldbfeed;
 #endif
 
 
@@ -27,7 +26,6 @@ output_module_t* output_modules[] = {
 	&module_extended_file,
 #ifdef REDIS
 	&module_redis,
-	&module_ssldbfeed,
 #endif
 	// ADD YOUR MODULE HERE
 };


### PR DESCRIPTION
The reference to ssldb was still in output_modules.c, this should fix things up to build with REDIS support.
