### PR TITLE
Use `git describe` to print correct version string

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ LDFLAGS+=$(EXTRALDFLAGS)
 
 modules=module_tcp_synscan.o module_icmp_echo.o module_udp.o #ADD YOUR MODULE HERE
 
-objects=constraint.o blacklist.o cyclic.o logger.o send.o recv.o state.o monitor.o zopt_compat.o zmap.o random.o output_modules.o module_simple_file.o module_extended_file.o packet.o probe_modules.o ${modules} validate.o rijndael-alg-fst.o get_gateway.o aesrand.o
+objects=constraint.o blacklist.o cyclic.o logger.o send.o recv.o state.o monitor.o zopt_compat.o zmap_version.o zmap.o random.o output_modules.o module_simple_file.o module_extended_file.o packet.o probe_modules.o ${modules} validate.o rijndael-alg-fst.o get_gateway.o aesrand.o
 redis_objects=module_redis.o redis.o
 
 ifeq ($(REDIS), true)
@@ -48,6 +48,9 @@ $(TARGETS):
 	$(CC) $(CFLAGS) $(DFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 zmap: $(objects) 
+
+zmap_version.o:
+	echo "const char *zmap_version(void) {return \"`git describe`\";}" | $(CC) -x c -c - -o $@ $(CFLAGS)
 
 zopt_compat.o: zopt.c
 

--- a/src/zopt_compat.c
+++ b/src/zopt_compat.c
@@ -4,4 +4,7 @@
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
+const char* zmap_version(void);
+#define CMDLINE_PARSER_VERSION zmap_version()
+
 #include "zopt.c"


### PR DESCRIPTION
Also leverage the zopt_compat file to replace the fixed version string
(that gengetopt requires) with a function call.

Fixes #36
