### PR TITLE
Install man files under $(PREFIX)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ PREFIX=/usr/local
 
 INSTALL=install
 INSTALLDATA=install -m 644
-mandir=/usr/share/man/man1/
+mandir=$(PREFIX)/man/man1/
 bindir=$(PREFIX)/sbin
 
 # Hardening and warnings for building with gcc
@@ -55,6 +55,7 @@ zopt.c zopt.h: zopt.ggo
 install: zmap
 	$(INSTALL) zmap $(bindir)/zmap
 	test -d /etc/zmap || (mkdir /etc/zmap && $(INSTALLDATA) ../conf/* /etc/zmap/)
+	test -d $(mandir) || mkdir -p $(mandir)
 	$(INSTALLDATA) ./zmap.1 $(mandir)
 	@echo "\n**************\nSuccess! ZMap is installed. Try running (as root):\nzmap -p 80 -N 10 -B 1M -o -\n**************"
 


### PR DESCRIPTION
Patch to move the install location for man pages to something under $(PREFIX), in common with $(bindir). Also try to create $(mandir) if it is missing.
