### PR TITLE
$(EXTRA_CFLAGS) FOR RPM %{optflags}

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@ GCCWARNINGS = -Wall -Wformat=2 -Wno-format-nonliteral\
 GCCHARDENING=-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fwrapv -fPIC --param ssp-buffer-size=1
 LDHARDENING=-z relro -z now
 
-EXTRACFLAGS=-std=gnu99 -g -O2 $(EXTRA_CFLAGS) $(GCCHARDENING) $(GCCWARNINGS) -Werror
+EXTRACFLAGS=-std=gnu99 -g -O2 $(GCCHARDENING) $(GCCWARNINGS) $(EXTRA_CFLAGS) -Werror
 EXTRALDFLAGS= $(LDHARDENING)
 
 CFLAGS+=$(INCLUDE) $(EXTRACFLAGS)


### PR DESCRIPTION
We RPM packaging system need to use optflags for secure building, and of course will override the flags you've defined.

However the current one is not good, we should leave it to the end of the flags queue.

[rpmaker@fab SPECS]$ rpm -E %{optflags}
-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches  -m32 -march=i686 -mtune=atom -fasynchronous-unwind-tables
