### PR TITLE
Update http-req

### DIFF
--- a/examples/banner-grab/http-req
+++ b/examples/banner-grab/http-req
@@ -1,3 +1,2 @@
 GET / HTTP/1.1
 Host: %s
-


### PR DESCRIPTION
zmap.armv7hl: W: wrong-file-end-of-line-encoding examples/banner-grab/http-req
This file has wrong end-of-line encoding, usually caused by creation or
modification on a non-Unix system. It could prevent it from being displayed
correctly in some circumstances.
