### PR TITLE
Add small network support to zmap.

### DIFF
--- a/lib/blacklist.h
+++ b/lib/blacklist.h
@@ -3,11 +3,17 @@
 #ifndef BLACKLIST_H
 #define BLACKLIST_H
 
+#define ADDR_DISALLOWED 0
+#define ADDR_ALLOWED 1
+
 int blacklist_is_allowed(uint32_t s_addr);
 void blacklist_prefix(char *ip, int prefix_len);
 void whitelist_prefix(char *ip, int prefix_len);
-int blacklist_init_from_files(char *whitelist, char*blacklist);
+int blacklist_load_from_files(char *whitelist, char*blacklist);
 uint64_t blacklist_count_allowed();
 uint64_t blacklist_count_not_allowed();
+void blacklist_init(int);
+void blacklist_optimize(void);
+void blacklist_free(void);
 
 #endif

--- a/src/cyclic.h
+++ b/src/cyclic.h
@@ -11,15 +11,19 @@
 #ifndef CYCLIC_H
 #define CYCLIC_H
 
-int cyclic_init(uint32_t, uint32_t);
+typedef struct cyclic_info cyclic_t;
+
+cyclic_t *cyclic_init(uint32_t, uint32_t);
 
 // get next IP address to scan
-uint32_t cyclic_get_next_ip(void);
+uint32_t cyclic_get_next_ip(cyclic_t *);
 
 // what IP address was returned last
 uint32_t cyclic_get_curr_ip(void);
 
 // what primitive root was generated for this current scan
 uint32_t cyclic_get_primroot(void);
+
+void cyclic_release(cyclic_t *);
 
 #endif

--- a/src/send.c
+++ b/src/send.c
@@ -48,12 +48,13 @@ static in_addr_t srcip_last;
 // offset send addresses according to a random chosen per scan execution
 // in order to help prevent cross-scan interference
 static uint32_t srcip_offset;
+static cyclic_t *cyclic;
 
 // global sender initialize (not thread specific)
 int send_init(void)
 {
 	// generate a new primitive root and starting position
-	cyclic_init(0, 0);
+	cyclic = cyclic_init(0, 0);
 	zsend.first_scanned = cyclic_get_curr_ip();
 
 	// compute number of targets
@@ -270,7 +271,7 @@ int send_run(int sock)
 			pthread_mutex_unlock(&send_mutex);
 			break;
 		}
-		uint32_t curr = cyclic_get_next_ip();
+		uint32_t curr = cyclic_get_next_ip(cyclic);
 		if (curr == zsend.first_scanned) {
 			zsend.complete = 1;
 			zsend.finish = now();

--- a/src/state.c
+++ b/src/state.c
@@ -47,6 +47,8 @@ struct state_conf zconf = {
 	.filter_duplicates = 0,
 	.filter_unsuccessful = 0,
 	.recv_ready = 0,
+	.startaddr = 0,
+	.nbits = 0,
 };
 
 // global sender stats and defaults

--- a/src/state.h
+++ b/src/state.h
@@ -86,6 +86,8 @@ struct state_conf {
 	int filter_duplicates;
 	int filter_unsuccessful;
 	int recv_ready;
+	uint32_t startaddr;
+	unsigned int nbits;
 };
 extern struct state_conf zconf;
 

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -6,9 +6,12 @@ zmap \- A fast Internet-wide scanner
 [ 
 .I "OPTIONS \&..."
 ] 
+[ 
+.I "A.B.C.D/M"
+] 
 .SH DESCRIPTION
 .I ZMap 
-is a network tool for scanning the entire Internet (or large samples).
+is a network tool for scanning arbitrary subsets of the Internet address space.
 .SH OPTIONS
 .SS "Basic options"
 .TP
@@ -131,6 +134,11 @@ Scan the whole Internet for hosts with port 443 open (results discarded):
 .PP
 .\" -p: example of
 .B zmap \-p 443
+.PP
+Scan a specific subnet for hosts with port 80 open, write results to file:
+.PP
+.\" -p: example of
+.B zmap -p 80 -o scan.out 192.168.0.0/16
 .PP
 Find 5 HTTP servers (port 80), scanning at 10 Mb/s, print the results to stdout:
 .PP

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -27,6 +27,7 @@
 
 #include <pthread.h>
 
+#include "../lib/blacklist.h"
 #include "../lib/logger.h"
 #include "../lib/random.h"
 
@@ -615,9 +616,44 @@ int main(int argc, char *argv[])
 			zconf.max_targets = v;
 		}
 	}
+	if (args.subnet_given) {
+		char ip[16];
+		struct in_addr saddr;
+		int mask;
+
+                if (sscanf(args.subnet_arg, "%15[^/]/%d", ip, &mask) != 2 ||
+                    inet_aton((const char *)ip, &saddr) == 0 ||
+                    mask < 0 || mask > 32) {
+			fprintf(stderr, "%s: can't parse CIDR `%s'\n",
+				CMDLINE_PARSER_PACKAGE, args.subnet_arg);
+			exit(EXIT_FAILURE);
+		}
+
+		blacklist_init(ADDR_DISALLOWED);
+		whitelist_prefix(inet_ntoa(saddr), mask);
+
+		zconf.startaddr = ntohl(saddr.s_addr);
+		zconf.nbits = mask;
+	} else {
+		if (zconf.whitelist_filename != NULL) {
+			// using a whitelist, so default to allowing nothing
+			blacklist_init(ADDR_DISALLOWED);
+		} else {
+			// no whitelist, so default to allowing everything
+			blacklist_init(ADDR_ALLOWED);
+		}
+	}
+
+	if (blacklist_load_from_files(zconf.whitelist_filename,
+	    zconf.blacklist_filename)) {
+		exit(EXIT_FAILURE);
+	}
+
+	blacklist_optimize();
 
 	start_zmap();
 
+	blacklist_free();
 	cmdline_parser_free(&args);
 	free(params);
 	return EXIT_SUCCESS;

--- a/src/zopt.c
+++ b/src/zopt.c
@@ -27,7 +27,7 @@
 
 const char *gengetopt_args_info_purpose = "A fast Internet-wide scanner.";
 
-const char *gengetopt_args_info_usage = "Usage: zmap [OPTIONS]...";
+const char *gengetopt_args_info_usage = "Usage: zmap [OPTIONS] [A.B.C.D/M]";
 
 const char *gengetopt_args_info_description = "";
 
@@ -69,7 +69,7 @@ const char *gengetopt_args_info_help[] = {
   "  -v, --verbosity=n             Level of log detail (0-5)  (default=`3')",
   "  -h, --help                    Print help and exit",
   "  -V, --version                 Print version and exit",
-  "\nExamples:\n     zmap -p 443  (scans the whole Internet for hosts with port 443 open)\n     zmap -N 5 -B 10M -p 80 -o -  (find 5 HTTP servers, scanning at 10 Mb/s)",
+  "\nExamples:\n     zmap -p 443  (scans the whole Internet for hosts with port 443 open)\n     zmap -p 80 192.168.0.0/16 (scan only the specified subnet)\n     zmap -N 5 -B 10M -p 80 -o -  (find 5 HTTP servers, scanning at 10 Mb/s)",
     0
 };
 
@@ -150,6 +150,7 @@ void clear_given (struct gengetopt_args_info *args_info)
   args_info->verbosity_given = 0 ;
   args_info->help_given = 0 ;
   args_info->version_given = 0 ;
+  args_info->subnet_given = 0 ;
 }
 
 static
@@ -199,6 +200,7 @@ void clear_args (struct gengetopt_args_info *args_info)
   args_info->config_orig = NULL;
   args_info->verbosity_arg = 3;
   args_info->verbosity_orig = NULL;
+  args_info->subnet_arg = NULL;
   
 }
 
@@ -1151,7 +1153,16 @@ cmdline_parser_internal (
         } /* switch */
     } /* while */
 
+  argc -= optind;
+  argv += optind;
 
+  /* Scan a particular subnet instead of the entire Internet (0/0) */
+  if (argc > 0) {
+          if (update_arg( (void *)&(args_info->subnet_arg), 
+              NULL, &(args_info->subnet_given), NULL, argv[0],
+	      0, 0, ARG_STRING, 0, 0, 0, 0, NULL, 0, additional_error))
+            goto failure;
+  }
 
 
   cmdline_parser_release (&local_args_info);

--- a/src/zopt.h
+++ b/src/zopt.h
@@ -117,6 +117,7 @@ struct gengetopt_args_info
   const char *verbosity_help; /**< @brief Level of log detail (0-5) help description.  */
   const char *help_help; /**< @brief Print help and exit help description.  */
   const char *version_help; /**< @brief Print version and exit help description.  */
+  char *subnet_arg; /**< @brief Netblock to scan. */
   
   unsigned int target_port_given ;	/**< @brief Whether target-port was given.  */
   unsigned int output_file_given ;	/**< @brief Whether output-file was given.  */
@@ -150,7 +151,7 @@ struct gengetopt_args_info
   unsigned int verbosity_given ;	/**< @brief Whether verbosity was given.  */
   unsigned int help_given ;	/**< @brief Whether help was given.  */
   unsigned int version_given ;	/**< @brief Whether version was given.  */
-
+  unsigned int subnet_given ;	/**< @brief Whether subnet was given. */
 } ;
 
 /** @brief The additional parameters to pass to parser functions */


### PR DESCRIPTION
The command line will now accept an optional CIDR address allowing the
user to narrow the search to a specific netblock.  Any blacklist or
whitelist that is also specified modifies the probing space, but the user
isn't forced to use these files to scope the work for quick scans.

The general idea is that a table is implemented containing parameters for
various smaller cyclic group sizes based on the given subnet mask.  This
is much more efficient than cycling through the entire 0/0 space when
scanning a much smaller portion of the Internet.
