### PR TITLE
Convert plain Makefile into cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required (VERSION 2.6)
+project (ZMAP C)
+
+option(WITH_REDIS "Build with support for Redis DB" OFF)
+option(WITH_JSON "Build with support for JSON" OFF)
+option(ENABLE_DEVELOPMENT "Enable development specific compiler and linker flags" OFF)
+option(ENABLE_HARDENING "Add hardening specific compiler and linker flags" OFF)
+
+if(ENABLE_DEVELOPMENT)
+	# Hardening and warnings for building with gcc
+	# Maybe add -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations
+	set(GCCWARNINGS 
+		"-Wall -Wformat=2 -Wno-format-nonliteral"
+		"-pedantic -fno-strict-aliasing"
+		"-Wextra"
+		"-Wfloat-equal -Wundef -Wwrite-strings -Wredundant-decls"
+		"-Wnested-externs -Wbad-function-cast -Winit-self"
+		"-Wmissing-noreturn -Wnormalized=id"
+		"-Wstack-protector"
+		"-Werror"
+		)
+
+	# Fix line breaks
+	string(REPLACE ";" " "  GCCWARNINGS "${GCCWARNINGS}")
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GCCWARNINGS} -g")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -g")
+endif()
+
+if(ENABLE_HARDENING)
+	set(GCCHARDENING "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fwrapv -fPIC --param ssp-buffer-size=1")
+	set(LDHARDENING "-z relro -z now")
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GCCHARDENING}")
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LDHARDENING}")
+endif()
+
+if(WITH_REDIS)
+	set(REDIS_LIBS hiredis)
+	add_definitions("-DREDIS")
+endif()
+
+if(WITH_JSON)
+	include(FindPkgConfig)
+	pkg_check_modules(JSON json-c)
+	if(NOT JSON_FOUND)
+		set(JSON_CFLAGS "")
+		set(JSON_LIBS "-ljson-c")
+		include_directories("/usr/local/include/json-c/")
+	endif()
+
+	add_definitions("-DJSON")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${JSON_CFLAGS}")
+endif()
+
+# Standard FLAGS
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+
+# Extra target FLAGS
+set(CMAKE_C_FLAGS_DEBUG "-O2 -g")
+set(CMAKE_C_FLAGS_RELEASE "-O2")
+
+add_subdirectory(src)
+
+# Install conf files
+FILE(GLOB CONF_FILES "conf/*")
+install(
+	FILES
+	${CONF_FILES}
+	DESTINATION "/etc/zmap/"
+	)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,94 @@
+include_directories(
+	"${CMAKE_CURRENT_BINARY_DIR}"
+	${PROJECT_SOURCE_DIR}/lib
+	${PROJECT_SOURCE_DIR}/src
+	${PROJECT_SOURCE_DIR}/src/output_modules
+	)
+
+SET(LIB_SOURCES
+	${PROJECT_SOURCE_DIR}/lib/blacklist.c
+	${PROJECT_SOURCE_DIR}/lib/constraint.c
+	${PROJECT_SOURCE_DIR}/lib/logger.c
+	${PROJECT_SOURCE_DIR}/lib/random.c
+	${PROJECT_SOURCE_DIR}/lib/rijndael-alg-fst.c
+)
+
+# ADD YOUR PROBE MODULE HERE
+SET(EXTRA_PROBE_MODULES
+
+	)
+
+# ADD YOUR OUTPUT MODULE HERE
+SET(EXTRA_OUTPUT_MODULES
+
+	)
+
+SET(OUTPUT_MODULE_SOURCES
+#	output_modules/module_extended_file.c
+#	output_modules/module_simple_file.c
+	output_modules/module_csv.c
+	output_modules/output_modules.c
+	)
+
+SET(PROBE_MODULE_SOURCES
+	probe_modules/module_icmp_echo.c
+	probe_modules/module_tcp_synscan.c
+	probe_modules/module_udp.c
+	probe_modules/packet.c
+	probe_modules/probe_modules.c
+	)
+
+SET(SOURCES
+	aesrand.c
+	cyclic.c
+	fieldset.c
+	get_gateway.c
+	monitor.c
+	recv.c
+	send.c
+	state.c
+	validate.c
+	zmap.c
+	zopt_compat.c
+	"${CMAKE_CURRENT_BINARY_DIR}/zopt.h"
+	${EXTRA_PROBE_MODULES}
+	${EXTRA_OUTPUT_MODULES}
+	${PROBE_MODULE_SOURCES}
+	${OUTPUT_MODULE_SOURCES}
+	${LIB_SOURCES}
+	)
+
+if (WITH_JSON)
+	SET(SOURCES ${SOURCES} output_modules/module_json.c)
+endif()
+
+if (WITH_REDIS)
+	SET(SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/lib/redis.c output_modules/module_redis.c)
+endif()
+
+add_custom_command(OUTPUT zopt.h
+	COMMAND gengetopt -C --no-help --no-version -i "${CMAKE_CURRENT_SOURCE_DIR}/zopt.ggo" -F "${CMAKE_CURRENT_BINARY_DIR}/zopt"
+	)
+
+add_executable(zmap ${SOURCES})
+
+target_link_libraries(
+	zmap 
+	pcap gmp m
+	${REDIS_LIBS}
+	${JSON_LIBRARIES}
+	)
+
+# Install binary
+install(
+	TARGETS
+	zmap
+	RUNTIME DESTINATION sbin
+)
+
+# Install Manpages
+install(
+	FILES
+	zmap.1
+	DESTINATION share/man/man1
+	)


### PR DESCRIPTION
As promised via mail I finally got around to convert the buildsystem into cmake. Please contact me for suggestion or enhancements.

The package can be configured with 4 different options:

-DWITH_REDIS=ON

Enable support for Redis DB

-DWITH_JSON=ON

Enable support for JSON based output

-DENABLE_DEVELOPMENT=ON

Enable all warnings and make them fatal

-DENABLE_HARDENING=ON

Compile and link with some hardening

Use the new system by creating a build directory and change into that.
And then call the following

cmake -DWITH_REDIS=OFF -DWITH_JSON=ON \
-DENABLE_DEVELOPMENT=ON -DENABLE_HARDENING=ON /path/to/source/dir/
make
make DESTDIR="/..." install

Signed-off-by: Justin Lecher jlec@gentoo.org
