### PR TITLE
Fix name of json-c pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 if(WITH_JSON)
 	include(FindPkgConfig)
-	pkg_check_modules(JSON json)
+	pkg_check_modules(JSON json-c)
 	if(JSON_FOUND)
 		include_directories(JSON_INCLUDE_DIRS)
 	else()


### PR DESCRIPTION
Over 2 years ago json-c renamed its pc file from json.pc -> json-c.pc.

Signed-off-by: Justin Lecher jlec@gentoo.org
