### PR TITLE
Fix call to pcap_dispatch

### DIFF
--- a/src/recv.c
+++ b/src/recv.c
@@ -210,7 +210,7 @@ int recv_run(pthread_mutex_t *recv_ready_mutex)
 		if (zconf.dryrun) {
 			sleep(1);
 		} else {
-			if (pcap_dispatch(pc, 0, packet_cb, NULL) == -1) {
+			if (pcap_dispatch(pc, -1, packet_cb, NULL) == -1) {
 				log_fatal("recv", "pcap_dispatch error");
 			}
 			if (zconf.max_results && zrecv.success_unique >= zconf.max_results) {


### PR DESCRIPTION
This fix allows using zmap with libpcap 1.5.1, the semantic difference
of values 0 and -1 of this parameter is not entirely clear:

```
"(In older versions of libpcap, the behavior when cnt was 0 was
undefined; different platforms and devices behaved differently, so
code that must work with older versions of libpcap should use -1,
not 0, as the value of cnt.)"
```

http://www.tcpdump.org/manpages/pcap_loop.3pcap.html

Just using -1 worked for me.
