### PR TITLE
Fix build errors on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ else()
 	set(USING_GCC "YES")
 endif()
 
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD" OR "${CMAKE_SYSTEM_NAME}" MATCHES "NetBSD")
+   set(BSD "YES")
+endif()
+
 # Hardening and warnings for building with gcc
 # Maybe add -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations
 set(GCCWARNINGS 
@@ -35,7 +39,7 @@ if(ENABLE_DEVELOPMENT)
 else()
 	# Hardening and optimizations for building with gcc
 	set(GCCHARDENING "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fwrapv -fPIC --param ssp-buffer-size=1")
-	if (NOT APPLE)
+	if (NOT APPLE AND NOT BSD)
 		set(LDHARDENING "-z relro -z now")
 	else()
 		set(LDHARDENING "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,11 @@ if (APPLE)
 	endif()
 endif()
 
+if (BSD)
+	include_directories(/usr/local/include)
+	link_directories(/usr/local/lib)
+endif()
+
 SET(LIB_SOURCES
 	${PROJECT_SOURCE_DIR}/lib/blacklist.c
 	${PROJECT_SOURCE_DIR}/lib/constraint.c
@@ -92,7 +97,7 @@ add_custom_command(OUTPUT parser.c
 
 add_executable(zmap ${SOURCES})
 
-if (APPLE)
+if (APPLE OR BSD)
 	set(DNET_LIBRARIES "dnet")
 else()
 	set(DNET_LIBRARIES "")

--- a/src/get_gateway.c
+++ b/src/get_gateway.c
@@ -31,6 +31,15 @@
 #include <net/if.h>
 #include <net/if_dl.h>
 
+#if !defined(__APPLE__)
+#include <dnet/os.h>
+#include <dnet/eth.h>
+#include <dnet/ip.h>
+#include <dnet/ip6.h>
+#include <dnet/addr.h>
+#include <dnet/arp.h>
+#endif
+
 int get_hw_addr(struct in_addr *gw_ip, UNUSED char *iface, unsigned char *hw_mac)
 {
 	arp_t *arp;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -27,7 +27,7 @@
 #include "../lib/random.h"
 #include "../lib/blacklist.h"
 
-#ifndef __linux__
+#if defined(__APPLE__)
 #include <mach/thread_act.h>
 #endif
 
@@ -156,6 +156,13 @@ static void set_cpu(void)
 }
 
 #else
+
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#define cpu_set_t cpuset_t
+#endif
+
 static void set_cpu(void)
 {
 	pthread_mutex_lock(&cpu_affinity_mutex);


### PR DESCRIPTION
Hi, I fixed the build errors on FreeBSD. Although I couldn't eliminate all warnings and the CMake files are not perfect, this should be a (big) step forward for BSD support.

Please tell me if you don't like something then I will correct it and modify the PR.

`-DENABLE_DEVELOPMENT` does not work because it treats all warnings as errors..

Related issue: https://github.com/zmap/zmap/issues/110

Best regards,
Clemens Gruber

@hukl: #FS124 :+1:
