### PR TITLE
Removed libevent1 dependencies (I think).

### DIFF
--- a/examples/banner-grab/banner-grab-tcp.c
+++ b/examples/banner-grab/banner-grab-tcp.c
@@ -11,7 +11,10 @@
 #include <arpa/inet.h>
 #include "logger.h"
 
-#include <event.h>
+// #include <event.h>
+#include <event2/event.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <event2/bufferevent_ssl.h>
 
 #include <getopt.h>


### PR DESCRIPTION
Seems to me the only reason that this required libevent 1 instead of libevent2 is it was still including the old headers. The new ones are split between more files, but still run the same way. 
