### PR TITLE
use cmake directives for flex, bison and gengetopt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,20 +85,21 @@ if (WITH_REDIS)
 	SET(SOURCES ${SOURCES} ${PROJECT_SOURCE_DIR}/lib/redis.c output_modules/module_redis.c output_modules/module_csvredis.c)
 endif()
 
+find_program(GENGETOPT gengetopt)
+if (NOT GENGETOPT)
+	message(FATAL_ERROR "Unable to find gengetopt")
+endif()
 add_custom_command(OUTPUT zopt.h
 	COMMAND gengetopt -C --no-help --no-version --unamed-opts=SUBNETS -i "${CMAKE_CURRENT_SOURCE_DIR}/zopt.ggo" -F "${CMAKE_CURRENT_BINARY_DIR}/zopt"
 	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/zopt.ggo"
 	)
 
-add_custom_command(OUTPUT lexer.c
-	COMMAND flex -o "${CMAKE_CURRENT_BINARY_DIR}/lexer.c" --header-file="${CMAKE_CURRENT_BINARY_DIR}/lexer.h" "${CMAKE_CURRENT_SOURCE_DIR}/lexer.l"
-	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/lexer.l"
-	)
+find_package(FLEX REQUIRED)
+flex_target(LEXER "${CMAKE_CURRENT_SOURCE_DIR}/lexer.l" "${CMAKE_CURRENT_BINARY_DIR}/lexer.c" COMPILE_FLAGS --header-file="${CMAKE_CURRENT_BINARY_DIR}/lexer.h")
 
-add_custom_command(OUTPUT parser.c
-	COMMAND byacc -d -o "${CMAKE_CURRENT_BINARY_DIR}/parser.c" "${CMAKE_CURRENT_SOURCE_DIR}/parser.y"
-	DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/parser.y"
-	)
+find_package(BISON REQUIRED)
+bison_target(PARSER "${CMAKE_CURRENT_SOURCE_DIR}/parser.y" "${CMAKE_CURRENT_BINARY_DIR}/parser.c" COMPILE_FLAGS -d)
+add_flex_bison_dependency(LEXER PARSER)
 
 add_executable(zmap ${SOURCES})
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-extern int yyparse();
-
 node_t *zfilter;
 
 static int validate_node(node_t *node, fielddefset_t *fields)


### PR DESCRIPTION
This commit replaces some custom commands with cmake directives for several tools in order to be cross platform and to show during the cmake phase if a tool is missing.
