### PR TITLE
remove redundant file exists check

### DIFF
--- a/src/zmap.c
+++ b/src/zmap.c
@@ -656,15 +656,6 @@ static void enforce_range(const char *name, int v, int min, int max)
 	}
 }
 
-static int file_exists(char *name)
-{
-	FILE *file = fopen(name, "r");
-	if (!file)
-		return 0;
-	fclose(file);
-	return 1;
-}
-
 #define MAC_LEN ETHER_ADDR_LEN
 int parse_mac(macaddr_t *out, char *in)
 {
@@ -704,7 +695,7 @@ int main(int argc, char *argv[])
 	if (cmdline_parser_ext(argc, argv, &args, params) != 0) {
 		exit(EXIT_SUCCESS);
 	}
-	if (args.config_given || file_exists(args.config_arg)) {
+	if (args.config_given) {
 		params->initialize = 0;
 		params->override = 0;
 		if (cmdline_parser_config_file(args.config_arg, &args, params) 


### PR DESCRIPTION
TOCTOU

This check is already done when cmdline_parser try to open the file
