### PR TITLE
Fix a segfault when udp->uh_ulen is less than 8

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -218,7 +218,12 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len, fieldset_t *f
 		fs_add_null(fs, "icmp_type");
 		fs_add_null(fs, "icmp_code");
 		fs_add_null(fs, "icmp_unreach_str");
-		fs_add_binary(fs, "data", (ntohs(udp->uh_ulen) - sizeof(struct udphdr)), (void*) &udp[1], 0);
+		// Verify that the UDP length is big enough for the header and at least one byte
+		if (ntohs(udp->uh_ulen) > sizeof(struct udphdr))
+			fs_add_binary(fs, "data", (ntohs(udp->uh_ulen) - sizeof(struct udphdr)), (void*) &udp[1], 0);
+		// Some devices reply with a zero UDP length but still return data, ignore these
+		else fs_add_null(fs, "data");
+
 	} else if (ip_hdr->ip_p == IPPROTO_ICMP) {
 		struct icmp *icmp = (struct icmp *) ((char *) ip_hdr + ip_hdr->ip_hl * 4);
 		struct ip *ip_inner = (struct ip *) &icmp[1];


### PR DESCRIPTION
This fixes a crash that occurs when a UDP response is received with a UDP length value less than the size of the UDP header. This cause the CSV output module to segfault and the JSON module to trigger an out of memory error. 

An example crash is below:

```
Program terminated with signal 11, Segmentation fault.
#0  hex_encode (len=18446744073709551608, readbuf=0x7f52dfd5e070 <Address 0x7f52dfd5e070 out of bounds>, f=0xfa59d0)
    at /root/zmap/src/output_modules/module_csv.c:69
69          fprintf(f, "%02x", readbuf[i]); 
```

A sample packet that triggers this:
    6.730450 aaa.bbb.ccc.ddd -> www.xxx.yyy.zzz.186 UDP 60 Source port: distinct  Destination port: 51121 [BAD UDP LENGTH 0 < 8]
