### PR TITLE
Added xalloc.o to Makefile

### DIFF
--- a/examples/forge-socket/Makefile
+++ b/examples/forge-socket/Makefile
@@ -15,7 +15,7 @@ LDFLAGS+=$(LDHARDENING)
 
 all: forge-socket
 
-forge-socket: forge-socket.o logger.o
+forge-socket: forge-socket.o xalloc.o logger.o
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
added missing xalloc.o to Makefile as function "xmalloc" is used in logger and failed to complete linking of logger.o.
