### PR TITLE
Improve pcap filter to avoid unusefull pkt get processed (feedback only)

### DIFF
--- a/src/recv.c
+++ b/src/recv.c
@@ -155,16 +155,16 @@ int recv_update_pcap_stats(void)
 int recv_run(pthread_mutex_t *recv_ready_mutex)
 {
 	char *final_pcap_filter;
-	const char *format_pcap_filter = "not src host %s and not dst net 224.0.0.0/4 and (%s)";
+	const char *format_final_pcap_filter = "not src host %s and not dst net 224.0.0.0/4 and (%s)";
 	size_t final_pcap_len = 0;
 
 	log_trace("recv", "recv thread started");
 	num_src_ports = zconf.source_port_last - zconf.source_port_first + 1;
 	log_debug("recv", "capturing responses on %s", zconf.iface);
 
-	final_pcap_len = strlen(zconf.probe_module->pcap_filter) + strlen(zconf.source_ip_first) + strlen(format_pcap_filter);
+	final_pcap_len = strlen(zconf.probe_module->pcap_filter) + strlen(zconf.source_ip_first) + strlen(format_final_pcap_filter);
 	final_pcap_filter = malloc(final_pcap_len);
-	snprintf(final_pcap_filter, final_pcap_len, format_pcap_filter , zconf.source_ip_first, zconf.probe_module->pcap_filter);
+	snprintf(final_pcap_filter, final_pcap_len, format_final_pcap_filter , zconf.source_ip_first, zconf.probe_module->pcap_filter);
 	log_debug("recv", "capturing filter is %s", final_pcap_filter);
 
 	if (!zconf.dryrun) {
@@ -181,7 +181,8 @@ int recv_run(pthread_mutex_t *recv_ready_mutex)
 		// - pkt sent from scan host (pkt src ip != scan src ip list)
 		// - pkt received to multicast ip addr 224.0.0.0/4
 
-		if (pcap_compile(pc, &bpf, zconf.probe_module->pcap_filter, 1, 0) < 0) {
+		// if (pcap_compile(pc, &bpf, zconf.probe_module->pcap_filter, 1, 0) < 0) {
+		if (pcap_compile(pc, &bpf, final_pcap_filter, 1, 0) < 0) {
 			log_fatal("recv", "couldn't compile filter");
 		}
 		if (pcap_setfilter(pc, &bpf) < 0) {


### PR DESCRIPTION
If I'm not wrong,  it seems to me that function "validate_packet" get called for each pkt matching pcap_filter (that is statically defined at compilation time). Then inside "validate_packet" code avoid processing unusefull pkt.

For some probe the pcap filter defined at compile time (with pkt's flag matching) can avoid this, but for other like udp probe this can't be done.

Why not reduce always calls to "validate packet" only to received usefull pkt?

This patch get pcap_filter CALCULATED AT RUNTIME to exclude:
- pkt generated from first scan host ip (to be improved for include source-ip range....)
- pkt received on multicast ip address (to check if can be improved avoiding promisc mode)

Feel free to comment..
MP
