### PR TITLE
Prevent exportable symbol conflicts when used as static/shared library

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -28,9 +28,9 @@ union node_value {
 	enum operation op;
 };
 
-typedef struct node {
-	struct node *left_child;
-	struct node *right_child;
+typedef struct node_st {
+	struct node_st *left_child;
+	struct node_st *right_child;
 	enum node_type type;
 	union node_value value;
 } node_t;

--- a/src/parser.y
+++ b/src/parser.y
@@ -22,7 +22,7 @@ extern node_t *zfilter;
 %union {
 	int int_literal;
 	char *string_literal;
-	struct node *expr; 
+	struct node_st *expr; 
 }
 
 %token '(' ')' T_AND T_OR


### PR DESCRIPTION
This PR renames the `node` struct defined in `expression.h` to `node_st` in an attempt to prevent exported symbol naming conflicts when used as static/shared library within other projects.

While I am certain this is not common, having this patch implemented upstream will help myself out (and possibly others) that wish to implement your applications functionality in additional projects. Thanks!
