### PR TITLE
Fix an edge case in find_primroot()

### DIFF
--- a/src/cyclic.c
+++ b/src/cyclic.c
@@ -115,6 +115,10 @@ static uint32_t find_primroot(const cyclic_group_t *group, aesrand_t *aes)
 	}
 	while (check_coprime(candidate, group) != COPRIME) {
 		++candidate;
+		//special case where we need to restart check from begin
+		if(candidate >= group->prime) { 
+			candidate = 1;
+		}
 	}
 	uint64_t retv = isomorphism(candidate, group);
 	return retv;


### PR DESCRIPTION
conditions :  prime == 257 and factor[] = [2] and candidate inital value == 256
on first loop check_coprime() will return NOT_COPRIME
line 117 ++candidate will make candidate==257
on second loop check_coprime() will return COPRIME
and then in isomorphism()  assert(additive_elt(257) < mult_group->prime(257)); will fail
Solution : reset candidate to minimal value (1)
