### PR TITLE
Mac address fields

### DIFF
--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -32,6 +32,7 @@ void print_macaddr(struct ifreq* i)
 #endif /* NDEBUG */
 
 #define IP_ADDR_LEN_STR 20
+#define MAC_ADDR_LEN_STR 18
 
 void fprintf_ip_header(FILE *fp, struct ip *iph)
 {
@@ -136,3 +137,12 @@ char *make_ip_str(uint32_t ip)
 	return retv;
 }
 
+// Note: caller must free return value
+char *make_mac_str(macaddr_t *mac)
+{
+	char *retv = xmalloc(MAC_ADDR_LEN_STR);
+	snprintf(retv, MAC_ADDR_LEN_STR, "%02x:%02x:%02x:%02x:%02x:%02x",
+		 (int) mac[0], (int) mac[1], (int) mac[2],
+		 (int) mac[3], (int) mac[4], (int) mac[5]);
+	return retv;
+}

--- a/src/probe_modules/packet.h
+++ b/src/probe_modules/packet.h
@@ -99,5 +99,6 @@ static __attribute__((unused)) inline uint16_t get_src_port(int num_ports,
 
 // Note: caller must free return value
 char *make_ip_str(uint32_t ip);
+char *make_mac_str(macaddr_t *mac);
 
 #endif

--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -53,6 +53,16 @@ void print_probe_modules(void)
 }
 
 
+void fs_add_eth_fields(fieldset_t *fs, struct ether_header *eth)
+{
+	// WARNING: you must update eth_fields_len  as well
+	// as the definitions set (eth_fields) if you
+	// change the fields added below:
+	fs_add_string(fs, "smac", make_mac_str(eth->ether_shost), 1);
+	fs_add_string(fs, "dmac", make_mac_str(eth->ether_dhost), 1);
+	fs_add_uint64(fs, "eth-type", eth->ether_type);
+}
+
 void fs_add_ip_fields(fieldset_t *fs, struct ip *ip)
 {
 	// WARNING: you must update ip_fields_len as well
@@ -85,6 +95,14 @@ void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown)
 	fs_add_uint64(fs, "timestamp-ts", (uint64_t) t.tv_sec);
 	fs_add_uint64(fs, "timestamp-us", (uint64_t) t.tv_usec);
 }
+
+int eth_fields_len = 3;
+fielddef_t eth_fields[] = {
+	{.name="smac", .type="string", .desc="source MAC address of response"},
+	{.name="dmac", .type="string", .desc="destination MAC address of response"},
+	{.name="eth-type", .type="int", .desc="ethernet packet type of response"}
+};
+
 
 int ip_fields_len = 6;
 fielddef_t ip_fields[] = {

--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -55,8 +55,8 @@ void print_probe_modules(void)
 
 void fs_add_ip_fields(fieldset_t *fs, struct ip *ip)
 {
-	// WARNING: you must update fs_ip_fields_len  as well
-	// as the definitions set (ip_fiels) if you
+	// WARNING: you must update ip_fields_len as well
+	// as the definitions set (ip_fields) if you
 	// change the fields added below:
 	fs_add_string(fs, "saddr", make_ip_str(ip->ip_src.s_addr), 1);
 	fs_add_uint64(fs, "saddr-raw", (uint64_t) ip->ip_src.s_addr);

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -51,12 +51,15 @@ typedef struct probe_module {
 
 probe_module_t* get_probe_module_by_name(const char*);
 
+void fs_add_eth_fields(fieldset_t *fs, struct ether_header *eth);
 void fs_add_ip_fields(fieldset_t *fs, struct ip *ip);
 void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown);
 void print_probe_modules(void);
 
+extern int eth_fields_len;
 extern int ip_fields_len;
 extern int sys_fields_len;
+extern fielddef_t eth_fields[];
 extern fielddef_t ip_fields[];
 extern fielddef_t sys_fields[];
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -65,6 +65,7 @@ void handle_packet(uint32_t buflen, const u_char *bytes) {
 		memcpy(&fake_eth_hdr[sizeof(struct ether_header)], bytes, buflen);
 		bytes = fake_eth_hdr;
 	}
+	fs_add_eth_fields(fs, (struct ether_header *) bytes);
 	zconf.probe_module->process_packet(bytes, buflen, fs);
 	fs_add_system_fields(fs, is_repeat, zsend.complete);
 	int success_index = zconf.fsconf.success_index;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -487,9 +487,10 @@ int main(int argc, char *argv[])
 	// now that we know the probe module, let's find what it supports
 	memset(&zconf.fsconf, 0, sizeof(struct fieldset_conf));
 	// the set of fields made available to a user is constructed
-	// of IP header fields + probe module fields + system fields
+	// of IP header fields + ether fields + probe module fields + system fields
 	fielddefset_t *fds = &(zconf.fsconf.defs);
 	gen_fielddef_set(fds, (fielddef_t*) &(ip_fields), ip_fields_len);
+	gen_fielddef_set(fds, (fielddef_t*) &(eth_fields), eth_fields_len);
 	gen_fielddef_set(fds, zconf.probe_module->fields,
 			zconf.probe_module->numfields);
 	gen_fielddef_set(fds, (fielddef_t*) &(sys_fields), sys_fields_len);


### PR DESCRIPTION
I added source and destination MAC fields to the output field list.  I understand they may be of limited use to the project but they can be helpful when scanning a local network.  If a scanning mode is selected which does not provide the ethernet header, the dummy values used for the probe modules will appear instead of the true MAC addresses.