### PR TITLE
Stop dropping UDP replies coming from non-destination ports

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -416,10 +416,10 @@ int udp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 
 		sport = ntohs(udp->uh_sport);
 		dport = ntohs(udp->uh_dport);
+		if (dport != zconf.target_port) {
+			return 0;
+		}
 	} else {
-		return 0;
-	}
-	if (dport != zconf.target_port) {
 		return 0;
 	}
 	if (!check_dst_port(sport, num_ports, validation)) {


### PR DESCRIPTION
Many UDP protocols respond from a port other than the one that was scanned. The dport validation logic makes sense for ICMP, but not for the UDP response itself, since it would drop valid responses.