### PR TITLE
Ignore traffic that doesn't come from the gateway

### DIFF
--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -52,7 +52,7 @@ void recv_init()
 	}
 	struct bpf_program bpf;
 
-	snprintf(bpftmp, sizeof(bpftmp-1), "ether src %02x:%02x:%02x:%02x:%02x:%02x and (%s)",
+	snprintf(bpftmp, sizeof(bpftmp)-1, "ether src %02x:%02x:%02x:%02x:%02x:%02x and (%s)",
 		zconf.gw_mac[0], zconf.gw_mac[1], zconf.gw_mac[2],
 		zconf.gw_mac[3], zconf.gw_mac[4], zconf.gw_mac[5],
 		zconf.probe_module->pcap_filter);

--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -42,6 +42,7 @@ void packet_cb(u_char __attribute__((__unused__)) *user,
 
 void recv_init()
 {
+	char bpftmp[1024];
 	char errbuf[PCAP_ERRBUF_SIZE];
 	pc = pcap_open_live(zconf.iface, zconf.probe_module->pcap_snaplen,
 					PCAP_PROMISC, PCAP_TIMEOUT, errbuf);
@@ -50,7 +51,13 @@ void recv_init()
 						zconf.iface, errbuf);
 	}
 	struct bpf_program bpf;
-	if (pcap_compile(pc, &bpf, zconf.probe_module->pcap_filter, 1, 0) < 0) {
+
+	snprintf(bpftmp, sizeof(bpftmp-1), "ether src %02x:%02x:%02x:%02x:%02x:%02x and (%s)",
+		zconf.gw_mac[0], zconf.gw_mac[1], zconf.gw_mac[2],
+		zconf.gw_mac[3], zconf.gw_mac[4], zconf.gw_mac[5],
+		zconf.probe_module->pcap_filter);
+
+	if (pcap_compile(pc, &bpf, bpftmp, 1, 0) < 0) {
 		log_fatal("recv", "couldn't compile filter");
 	}
 	if (pcap_setfilter(pc, &bpf) < 0) {


### PR DESCRIPTION
This is a retake of issue #246 that prefixes the pcap filter with a rule dropping all traffic that does not originate from the detected or configured gateway MAC address. This seems to comprehensively fix the issue with the receive functions seeing sent traffic. 