### PR TITLE
Change send_run to better handle small rates.

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -213,14 +213,26 @@ int send_run(sock_t st, shard_t *s)
 	int interval = 0;
 	uint32_t max_targets = s->state.max_targets;
 	volatile int vi;
+    struct timespec ts, rem;
+    double send_rate = (double) zconf.rate / zconf.senders;
+    double slow_rate = 50; // packets per seconds per thread at which it uses the slow methos
+    long nsec_per_sec = 1000 * 1000 * 1000;
+    long long sleep_time = nsec_per_sec;
 	if (zconf.rate > 0) {
-		// estimate initial rate
 		delay = 10000;
-		for (vi = delay; vi--; )
-			;
-		delay *= 1 / (now() - last_time) / (zconf.rate / zconf.senders);
-		interval = (zconf.rate / zconf.senders) / 20;
-		last_time = now();
+        
+        if (send_rate < slow_rate) {
+            // set the inital time difference
+            sleep_time = nsec_per_sec / send_rate;
+            last_time = now() - (1.0 / send_rate);
+        } else {
+		    // estimate initial rate
+		    for (vi = delay; vi--; )
+		    	;
+		    delay *= 1 / (now() - last_time) / (zconf.rate / zconf.senders);
+		    interval = (zconf.rate / zconf.senders) / 20;
+		    last_time = now();
+        }
 	}
 	uint32_t curr = shard_get_cur_ip(s);
 	int attempts = zconf.num_retries + 1;
@@ -229,17 +241,30 @@ int send_run(sock_t st, shard_t *s)
 		// adaptive timing delay
 		if (delay > 0) {
 			count++;
-			for (vi = delay; vi--; )
-				;
-			if (!interval || (count % interval == 0)) {
-				double t = now();
-				delay *= (double)(count - last_count)
-					/ (t - last_time) / (zconf.rate / zconf.senders);
-				if (delay < 1)
-					delay = 1;
-				last_count = count;
-				last_time = t;
-			}
+            if (send_rate < slow_rate) {
+                double t = now();
+                double last_rate = (1.0 / (t - last_time));
+
+                sleep_time *= ((last_rate / send_rate) + 1) / 2;
+                ts.tv_sec = sleep_time / nsec_per_sec;
+                ts.tv_nsec = sleep_time % nsec_per_sec;
+                log_debug("sleep", "sleep for %d sec, %ld nanoseconds", ts.tv_sec, ts.tv_nsec);
+                while (nanosleep(&ts, &rem) == -1) {}
+                
+                last_time = t;
+            } else {
+			    for (vi = delay; vi--; )
+			    	;
+			    if (!interval || (count % interval == 0)) {
+			    	double t = now();
+			    	delay *= (double)(count - last_count)
+			    		/ (t - last_time) / (zconf.rate / zconf.senders);
+			    	if (delay < 1)
+			    		delay = 1;
+			    	last_count = count;
+			    	last_time = t;
+			    }
+            }
 		}
 		if (zrecv.complete) {
 			s->cb(s->id, s->arg);


### PR DESCRIPTION
I want to use zmap but with small rates (of a few packets per second). So I needed to fix the send_loop.
If the packet rate is smaller than the number of thread the interval gets rounded to 0 and is ignored than. The second problem is that the busy loop consumes too much CPU. So I use nanosleep to wait the expected time. This is an additional code path in send_run but shouldn't not matter performance wise due to branch prediction. Also packet rates smaller than number of threads are now possible.

I left the rest of the code unchanged as much as possible because I am not sure if something relies on the divide to 0 behavior. 