### PR TITLE
Made output filters support fields with underscore or hyphen

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -31,6 +31,6 @@
 "<"                  return '<';
 "("                  return '(';
 ")"                  return ')';
-[a-zA-Z][a-zA-Z0-9]+ yylval.string_literal = strdup(yytext); return T_FIELD;
+[a-zA-Z][-_a-zA-Z0-9]+ yylval.string_literal = strdup(yytext); return T_FIELD;
 
 %%


### PR DESCRIPTION
Simply extended the lexer grammar to make `T_FIELD` also match underscore and hyphen (`[a-zA-Z][-_a-zA-Z0-9]+`).

Resolves #291.