### PR TITLE
Handle Unsafe utf8 strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq build-essential libtool autoconf automake
 - sudo apt-get install -qq libgmp3-dev gengetopt libpcap-dev flex byacc pkg-config
-  libhiredis-dev
+  libhiredis-dev libunistring-dev
 - sudo apt-get install libsasl2-dev
 - sudo pip install sh
 - python ./scripts/install_cmake.py

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,6 +29,7 @@ You can also build ZMap from sources, following fundamentals required:
   - [libpcap](http://www.tcpdump.org/) - Famous user-level packet capture library
   - [flex](http://flex.sourceforge.net/) and [byacc](http://invisible-island.net/byacc/) - Output filter lexer and parser generator.
   - [json-c](https://github.com/json-c/json-c/) - JSON implementation in C
+  - [libunistring](https://www.gnu.org/software/libunistring/) - Unicode string library for C
 
 In addition, you can get following packages to get further functionalities:
   - [hiredis](https://github.com/redis/hiredis) - RedisDB support in C
@@ -42,17 +43,17 @@ In addition, you can get following packages to get further functionalities:
 
 * On Debian-based systems by running:
    ```sh
-   sudo apt-get install build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config
+   sudo apt-get install build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config libunistring-dev
    ```
 
 * On RHEL- and Fedora-based systems by running:
    ```sh
-   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel
+   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring
    ```
 
 * On Mac OS systems [Homebrew](http://brew.sh/):
   ```sh
-  brew install cmake gmp gengetopt json-c byacc libdnet
+  brew install cmake gmp gengetopt json-c byacc libdnet libunistring
   ```
 
 Once these prerequisites have been installed, ZMap can be compiled

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,7 +176,7 @@ target_link_libraries(
     zmap
     zmaplib
     ${PFRING_LIBRARIES}
-    pcap gmp m
+    pcap gmp m unistring
     ${DNET_LIBRARIES}
     ${REDIS_LIBS}
     ${JSON_LIBRARIES}
@@ -199,7 +199,7 @@ target_link_libraries(
     ztests
     zmaplib
     ${PFRING_LIBRARIES}
-    pcap gmp m
+    pcap gmp m unistring
     ${DNET_LIBRARIES}
     ${REDIS_LIBS}
     ${JSON_LIBRARIES}

--- a/src/fieldset.c
+++ b/src/fieldset.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <unistr.h>
 
 #include "../lib/logger.h"
 #include "../lib/xalloc.h"
@@ -29,7 +30,7 @@ void gen_fielddef_set(fielddefset_t *fds, fielddef_t fs[], int len)
 fieldset_t *fs_new_fieldset(void)
 {
 	fieldset_t *f = xcalloc(1, sizeof(fieldset_t));
-    f->len = 0;
+	f->len = 0;
 	f->type = FS_FIELDSET;
 	return f;
 }
@@ -37,7 +38,7 @@ fieldset_t *fs_new_fieldset(void)
 fieldset_t *fs_new_repeated_field(int type, int free_)
 {
 	fieldset_t *f = xcalloc(1, sizeof(fieldset_t));
-    f->len = 0;
+	f->len = 0;
 	f->type = FS_REPEATED;
 	f->inner_type = type;
 	f->free_ = free_;
@@ -102,6 +103,64 @@ static void fs_modify_word(fieldset_t *fs, const char *name, int type,
 	fs_add_word(fs, name, type, free_, len, value);
 }
 
+static char *sanitize_utf8(const char *buf)
+{
+	const char *ptr = buf;
+
+	// Count how many errors we encounter
+	uint32_t i = 0;
+	// Upper bounds to ensure termination even if u8_check is unsafe
+	while (i < strlen(buf) && ptr < buf + strlen(buf)) {
+		ptr = (char*)u8_check((uint8_t*)ptr, strlen(ptr));
+		if (ptr == NULL) {
+			break;
+		}
+
+		assert(ptr >= buf);
+		assert(ptr < buf + strlen(buf));
+
+		ptr++;
+		i++;
+	}
+
+	// i is the total number of errors. We need 5 characters for each error \u00XX
+	char *safe_buf = xmalloc(strlen(buf) + i*5 + 1);
+	char *safe_ptr = NULL;
+	memcpy(safe_buf, buf, strlen(buf));
+
+	// Fix exactly i errors
+	for (uint32_t j = 0; j < i; j++) {
+		// Always operate on the working buffer
+		safe_ptr = (char*)u8_check((uint8_t*)safe_buf, strlen(safe_buf));
+
+		// This implies we had less errors than we should.
+		assert(safe_ptr != NULL);
+		assert(safe_ptr >= safe_buf);
+		assert(safe_ptr < safe_buf + strlen(safe_buf));
+
+		// Shift the rest of the string by 5 chars
+		if (strlen(safe_ptr) > 1) {
+			memcpy(safe_ptr + 6, safe_ptr + 1, strlen(safe_ptr + 1));
+		}
+
+		// Write out the hex for the bad byte
+		char temp[7];
+		memset(temp, 0x00, 7);
+		snprintf(temp, 7, "\\u00%2hhX", safe_ptr[0]);
+
+		memcpy(safe_ptr, temp, 6);
+	}
+
+	// We now have a valid utf8 string
+	assert(u8_check((uint8_t*)safe_buf, strlen(safe_buf)) == NULL);
+	// We should be null terminated
+	assert(safe_buf[strlen(buf) + i*5] == '\0');
+	// We should be the right length
+	assert(strlen(safe_buf) == (strlen(buf) + i*5));
+
+	return safe_buf;
+}
+
 void fs_add_null(fieldset_t *fs, const char *name)
 {
 	field_val_t val = { .ptr = NULL };
@@ -112,6 +171,23 @@ void fs_add_string(fieldset_t *fs, const char *name, char *value, int free_)
 {
 	field_val_t val = { .ptr = value };
 	fs_add_word(fs, name, FS_STRING, free_, strlen(value), val);
+}
+
+void fs_add_unsafe_string(fieldset_t *fs, const char *name, char *value, int free_)
+{
+	if (u8_check((uint8_t*)value, strlen(value)) == NULL) {
+		field_val_t val = { .ptr = value };
+		fs_add_word(fs, name, FS_STRING, free_, strlen(value), val);
+	} else {
+		char* safe_value = sanitize_utf8(value);
+
+		if (free_) {
+			free(value);
+		}
+
+		field_val_t val = { .ptr = safe_value };
+		fs_add_word(fs, name, FS_STRING, 1, strlen(safe_value), val);
+	}
 }
 
 void fs_chkadd_string(fieldset_t *fs, const char *name, char *value, int free_)
@@ -203,9 +279,9 @@ int fds_get_index_by_name(fielddefset_t *fds, char *name)
 
 void field_free(field_t *f)
 {
-    if (f->type == FS_FIELDSET || f->type == FS_REPEATED) {
-        fs_free((fieldset_t *) f->value.ptr);
-    } else if (f->free_) {
+	if (f->type == FS_FIELDSET || f->type == FS_REPEATED) {
+		fs_free((fieldset_t *) f->value.ptr);
+	} else if (f->free_) {
 		free(f->value.ptr);
 	}
 }
@@ -217,7 +293,7 @@ void fs_free(fieldset_t *fs)
 	}
 	for (int i=0; i < fs->len; i++) {
 		field_t *f = &(fs->fields[i]);
-        field_free(f);
+		field_free(f);
 	}
 	free(fs);
 }

--- a/src/fieldset.c
+++ b/src/fieldset.c
@@ -123,7 +123,7 @@ static char *sanitize_utf8(const char *buf)
 		i++;
 	}
 
-	// i is the total number of errors. We need 5 characters for each error \u00XX
+	// i is the total number of errors. We need 5 more chars for each error \u00XX
 	char *safe_buf = xmalloc(strlen(buf) + i*5 + 1);
 	char *safe_ptr = NULL;
 	memcpy(safe_buf, buf, strlen(buf));

--- a/src/fieldset.h
+++ b/src/fieldset.h
@@ -99,6 +99,8 @@ void fs_add_uint64(fieldset_t *fs, const char *name, uint64_t value);
 
 void fs_add_string(fieldset_t *fs, const char *name, char *value, int free_);
 
+void fs_add_unsafe_string(fieldset_t *fs, const char *name, char *value, int free_);
+
 void fs_chkadd_string(fieldset_t *fs, const char *name, char *value, int free_);
 
 void fs_add_constchar(fieldset_t *fs, const char *name, const char *value);

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -403,7 +403,7 @@ static bool process_response_question(char **data, uint16_t* data_len,
 	
 	// Build our new question fieldset
 	fieldset_t *qfs = fs_new_fieldset(); 
-	fs_add_string(qfs, "name", question_name, 1);
+	fs_add_unsafe_string(qfs, "name", question_name, 1);
 	fs_add_uint64(qfs, "qtype", qtype);
 	if (qtype > MAX_QTYPE || qtype_qtype_to_strid[qtype] == BAD_QTYPE_VAL) {
 		fs_add_string(qfs, "qtype_str", (char*) BAD_QTYPE_STR, 0);
@@ -464,7 +464,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 
 	// Build our new question fieldset
 	fieldset_t *afs = fs_new_fieldset(); 
-	fs_add_string(afs, "name", answer_name, 1);
+	fs_add_unsafe_string(afs, "name", answer_name, 1);
 	fs_add_uint64(afs, "type", type);
 	if (type > MAX_QTYPE || qtype_qtype_to_strid[type] == BAD_QTYPE_VAL) {
 		fs_add_string(afs, "type_str", (char*) BAD_QTYPE_STR, 0);
@@ -489,7 +489,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 			fs_add_binary(afs, "rdata", rdlength, rdata, 0);
 		} else {
 			fs_add_uint64(afs, "rdata_is_parsed", 1);
-			fs_add_string(afs, "rdata", rdata_name, 1);
+			fs_add_unsafe_string(afs, "rdata", rdata_name, 1);
 		}
 
 	 } else if (type == DNS_QTYPE_MX) {
@@ -518,7 +518,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 						strlen(rdata_name));
 
 				fs_add_uint64(afs, "rdata_is_parsed", 1);
-				fs_add_string(afs, "rdata", rdata_with_pref, 1);
+				fs_add_unsafe_string(afs, "rdata", rdata_with_pref, 1);
 			}
 		}
 	} else if (type == DNS_QTYPE_TXT) {
@@ -531,7 +531,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 			fs_add_uint64(afs, "rdata_is_parsed", 1);
 			char* txt = xmalloc(rdlength);
 			memcpy(txt, rdata + 1, rdlength-1);
-			fs_add_string(afs, "rdata", txt, 1);
+			fs_add_unsafe_string(afs, "rdata", txt, 1);
 		}
 	} else if (type == DNS_QTYPE_A) {
 
@@ -542,7 +542,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 			fs_add_binary(afs, "rdata", rdlength, rdata, 0);
 		} else {
 			fs_add_uint64(afs, "rdata_is_parsed", 1);
-			fs_add_string(afs, "rdata", 
+			fs_add_unsafe_string(afs, "rdata",
 				(char*) inet_ntoa( *(struct in_addr*)rdata ), 0);
 		}
 	} else if (type == DNS_QTYPE_AAAA) {
@@ -559,7 +559,7 @@ static bool process_response_answer(char **data, uint16_t* data_len,
 			inet_ntop(AF_INET6, (struct sockaddr_in6*)rdata, 
 					ipv6_str,INET6_ADDRSTRLEN);
 
-			fs_add_string(afs, "rdata", ipv6_str, 1);
+			fs_add_unsafe_string(afs, "rdata", ipv6_str, 1);
 		}
 	} else {
 		fs_add_uint64(afs, "rdata_is_parsed", 0);


### PR DESCRIPTION
This addresses https://github.com/zmap/zmap/issues/301 by requiring that potentially unsafe strings be handled via the new fieldset operation fs_add_unsafe_string().

fs_add_unsafe_string() is designed to be used when you are supposed be given utf8 but the string may be malformed (e.g. you yanked it out of a DNS packet). fs_add_unsafe_string() will check if the string is a valid utf8 encoding. If not it will escape the offending byte as \u00XX.

A drawback here is we don't escape the escape character. This makes it impossible to differentiate between an escaped sequence and those bytes actually being in the string. Given that this is an extreme corner case (currently 1 server on the Internet, one protocol) I believe not altering the escape character is the right call. Especially given that any string emitted by this operation could just as easily be marked as a complete error and discarded.

Marked as ZMap 3.0 given that this pulls in a new library.

Note: TravisCI fails because the required library is not on the CI server.