### PR TITLE
Update missing dependencies on Fedora based systems

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ In addition, you can get following packages to get further functionalities:
 
 * On RHEL- and Fedora-based systems by running:
    ```sh
-   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring
+   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring libunistring-devel
    ```
 
 * On Mac OS systems [Homebrew](http://brew.sh/):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ In addition, you can get following packages to get further functionalities:
 
 * On RHEL- and Fedora-based systems by running:
    ```sh
-   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring libunistring-devel
+   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel
    ```
 
 * On Mac OS systems [Homebrew](http://brew.sh/):


### PR DESCRIPTION
fatal error: unistr.h: No such file or directory when trying to compile without libunistring-devel installed.