### PR TITLE
Correct length of templatized UDP payloads 

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -278,6 +278,9 @@ int udp_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
 		// The buf is a stack var of our caller of size MAX_PACKET_SIZE
 		// Recalculate the payload using the loaded template
 		payload_len = udp_template_build(udp_template, payload, MAX_UDP_PAYLOAD_LEN, ip_header, udp_header, aes);
+		// Recalculate the total length of the packet
+		module_udp.packet_length = sizeof(struct ether_header) + sizeof(struct ip)
+			+ sizeof(struct udphdr) + payload_len;
 
 		// If success is zero, the template output was truncated
 		if (payload_len <= 0) {

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -173,6 +173,7 @@ int udp_global_initialize(struct state_conf *conf) {
 		if (strcmp(args, "template") == 0) {
 			udp_send_substitutions = 1;
 			udp_template = udp_template_load(udp_send_msg, udp_send_msg_len);
+			udp_send_msg_len = udp_template->length;
 		}
 
 	} else if (strcmp(args, "hex") == 0) {
@@ -461,6 +462,7 @@ void udp_template_add_field(udp_payload_template_t *t,
 	c->ftype	= ftype;
 	c->length = length;
 	c->data	 = data;
+	t->length += length;
 }
 
 // Free all buffers held by the payload template, including its own
@@ -675,6 +677,7 @@ int udp_template_field_lookup(char *vname, udp_payload_field_t *c)
 udp_payload_template_t * udp_template_load(char *buf, unsigned int len)
 {
 	udp_payload_template_t *t = xmalloc(sizeof(udp_payload_template_t));
+	t->length = 0;
 
 	// The last $ we encountered outside of a field specifier
 	char *dollar = NULL;

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -173,7 +173,6 @@ int udp_global_initialize(struct state_conf *conf) {
 		if (strcmp(args, "template") == 0) {
 			udp_send_substitutions = 1;
 			udp_template = udp_template_load(udp_send_msg, udp_send_msg_len);
-			udp_send_msg_len = udp_template->length;
 		}
 
 	} else if (strcmp(args, "hex") == 0) {
@@ -462,7 +461,6 @@ void udp_template_add_field(udp_payload_template_t *t,
 	c->ftype	= ftype;
 	c->length = length;
 	c->data	 = data;
-	t->length += length;
 }
 
 // Free all buffers held by the payload template, including its own
@@ -677,7 +675,6 @@ int udp_template_field_lookup(char *vname, udp_payload_field_t *c)
 udp_payload_template_t * udp_template_load(char *buf, unsigned int len)
 {
 	udp_payload_template_t *t = xmalloc(sizeof(udp_payload_template_t));
-	t->length = 0;
 
 	// The last $ we encountered outside of a field specifier
 	char *dollar = NULL;

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -633,7 +633,7 @@ int udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 		}
 	}
 
-	return p - out - 1;
+	return p - out;
 }
 
 // Convert a string field name to a field type, parsing any specified length value

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -45,6 +45,7 @@ typedef struct udp_payload_field
 typedef struct udp_payload_template
 {
 	unsigned int fcount;
+	unsigned int length;
 	struct udp_payload_field **fields;
 } udp_payload_template_t;
 

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -45,7 +45,6 @@ typedef struct udp_payload_field
 typedef struct udp_payload_template
 {
 	unsigned int fcount;
-	unsigned int length;
 	struct udp_payload_field **fields;
 } udp_payload_template_t;
 


### PR DESCRIPTION
Fixes #343.

Tested by using the zmap-supplied `sip_options.tpl` template file as both a file and a template.  When used as a file, the UDP payload is literally the contents of this file,  uninterpolated, and there are no trailing nulls, incorrect IP or UDP header lengths or anomalies noticed by wireshark:


```
(with tcpdump running)
$  ./src/zmap -q -i en0 -s 5060 -p 5060 192.168.0.1 -M udp --probe-args=file:./examples/udp-probes/sip_options.tpl
May 06 09:33:32.032 [WARN] zmap: too few targets relative to senders, dropping to one sender
May 06 09:33:32.032 [INFO] zmap: output module: csv
May 06 09:33:32.032 [INFO] csv: no output file selected, will use stdout
09:33:32.040647 ac:bc:32:b6:29:67 > bc:14:01:57:0b:52, ethertype IPv4 (0x0800), length 464: 192.168.0.19.5060 > 192.168.0.1.5060: SIP: OPTIONS sip:${RAND_ALPHA=8}@${DADDR} SIP/2.0
        0x0000:  4500 01c2 d431 0000 ff11 6494 c0a8 0013  E....1....d.....
        0x0010:  c0a8 0001 13c4 13c4 01ae 0000 4f50 5449  ............OPTI
        0x0020:  4f4e 5320 7369 703a 247b 5241 4e44 5f41  ONS.sip:${RAND_A
        0x0030:  4c50 4841 3d38 7d40 247b 4441 4444 527d  LPHA=8}@${DADDR}
        0x0040:  2053 4950 2f32 2e30 0d0a 5669 613a 2053  .SIP/2.0..Via:.S
        0x0050:  4950 2f32 2e30 2f55 4450 2024 7b53 4144  IP/2.0/UDP.${SAD
        0x0060:  4452 7d3a 247b 5350 4f52 547d 3b62 7261  DR}:${SPORT};bra
        0x0070:  6e63 683d 247b 5241 4e44 5f41 4c50 4841  nch=${RAND_ALPHA
        0x0080:  3d36 7d2e 247b 5241 4e44 5f44 4947 4954  =6}.${RAND_DIGIT
        0x0090:  3d31 307d 3b72 706f 7274 3b61 6c69 6173  =10};rport;alias
        0x00a0:  0d0a 4672 6f6d 3a20 7369 703a 247b 5241  ..From:.sip:${RA
        0x00b0:  4e44 5f41 4c50 4841 3d38 7d40 247b 5341  ND_ALPHA=8}@${SA
        0x00c0:  4444 527d 3a24 7b53 504f 5254 7d3b 7461  DDR}:${SPORT};ta
        0x00d0:  673d 247b 5241 4e44 5f44 4947 4954 3d38  g=${RAND_DIGIT=8
        0x00e0:  7d0d 0a54 6f3a 2073 6970 3a24 7b52 414e  }..To:.sip:${RAN
        0x00f0:  445f 414c 5048 413d 387d 4024 7b44 4144  D_ALPHA=8}@${DAD
        0x0100:  4452 7d0d 0a43 616c 6c2d 4944 3a20 247b  DR}..Call-ID:.${
        0x0110:  5241 4e44 5f44 4947 4954 3d31 307d 4024  RAND_DIGIT=10}@$
        0x0120:  7b53 4144 4452 7d0d 0a43 5365 713a 2031  {SADDR}..CSeq:.1
        0x0130:  204f 5054 494f 4e53 0d0a 436f 6e74 6163  .OPTIONS..Contac
        0x0140:  743a 2073 6970 3a24 7b52 414e 445f 414c  t:.sip:${RAND_AL
        0x0150:  5048 413d 387d 4024 7b53 4144 4452 7d3a  PHA=8}@${SADDR}:
        0x0160:  247b 5350 4f52 547d 0d0a 436f 6e74 656e  ${SPORT}..Conten
        0x0170:  742d 4c65 6e67 7468 3a20 300d 0a4d 6178  t-Length:.0..Max
        0x0180:  2d46 6f72 7761 7264 733a 2032 300d 0a55  -Forwards:.20..U
        0x0190:  7365 722d 4167 656e 743a 2024 7b52 414e  ser-Agent:.${RAN
        0x01a0:  445f 414c 5048 413d 387d 0d0a 4163 6365  D_ALPHA=8}..Acce
        0x01b0:  7074 3a20 7465 7874 2f70 6c61 696e 0d0a  pt:.text/plain..
        0x01c0:  0d0a                                     ..
```

When used as a template, the UDP payload is the contents of the file with the interpolation complete.  The lengths are now correct so that they reflect the size of payload rather than size of the template used to produce the template:

```
(with tcpdump running)
$  ./src/zmap -q -i en0 -s 5060 -p 5060 192.168.0.1 -M udp --probe-args=template:./examples/udp-probes/sip_options.tpl
May 06 09:34:06.211 [WARN] zmap: too few targets relative to senders, dropping to one sender
May 06 09:34:06.211 [INFO] zmap: output module: csv
May 06 09:34:06.212 [INFO] csv: no output file selected, will use stdout
09:34:06.218809 ac:bc:32:b6:29:67 > bc:14:01:57:0b:52, ethertype IPv4 (0x0800), length 411: 192.168.0.19.5060 > 192.168.0.1.5060: SIP: OPTIONS sip:lFVMYTBG@192.168.0.1 SIP/2.0
        0x0000:  4500 018d d431 0000 ff11 64c9 c0a8 0013  E....1....d.....
        0x0010:  c0a8 0001 13c4 13c4 0179 0000 4f50 5449  .........y..OPTI
        0x0020:  4f4e 5320 7369 703a 6c46 564d 5954 4247  ONS.sip:lFVMYTBG
        0x0030:  4031 3932 2e31 3638 2e30 2e31 2053 4950  @192.168.0.1.SIP
        0x0040:  2f32 2e30 0d0a 5669 613a 2053 4950 2f32  /2.0..Via:.SIP/2
        0x0050:  2e30 2f55 4450 2031 3932 2e31 3638 2e30  .0/UDP.192.168.0
        0x0060:  2e31 393a 3530 3630 3b62 7261 6e63 683d  .19:5060;branch=
        0x0070:  4449 4474 6343 2e35 3036 3634 3834 3238  DIDtcC.506648428
        0x0080:  313b 7270 6f72 743b 616c 6961 730d 0a46  1;rport;alias..F
        0x0090:  726f 6d3a 2073 6970 3a4a 4247 7171 5978  rom:.sip:JBGqqYx
        0x00a0:  7340 3139 322e 3136 382e 302e 3139 3a35  s@192.168.0.19:5
        0x00b0:  3036 303b 7461 673d 3931 3434 3033 3539  060;tag=91440359
        0x00c0:  0d0a 546f 3a20 7369 703a 486b 624a 6c75  ..To:.sip:HkbJlu
        0x00d0:  5662 4031 3932 2e31 3638 2e30 2e31 0d0a  Vb@192.168.0.1..
        0x00e0:  4361 6c6c 2d49 443a 2030 3537 3434 3838  Call-ID:.0574488
        0x00f0:  3335 3440 3139 322e 3136 382e 302e 3139  354@192.168.0.19
        0x0100:  0d0a 4353 6571 3a20 3120 4f50 5449 4f4e  ..CSeq:.1.OPTION
        0x0110:  530d 0a43 6f6e 7461 6374 3a20 7369 703a  S..Contact:.sip:
        0x0120:  5647 4956 5a51 6e78 4031 3932 2e31 3638  VGIVZQnx@192.168
        0x0130:  2e30 2e31 393a 3530 3630 0d0a 436f 6e74  .0.19:5060..Cont
        0x0140:  656e 742d 4c65 6e67 7468 3a20 300d 0a4d  ent-Length:.0..M
        0x0150:  6178 2d46 6f72 7761 7264 733a 2032 300d  ax-Forwards:.20.
        0x0160:  0a55 7365 722d 4167 656e 743a 207a 724b  .User-Agent:.zrK
        0x0170:  6255 504e 430d 0a41 6363 6570 743a 2074  bUPNC..Accept:.t
        0x0180:  6578 742f 706c 6169 6e0d 0a0d 0a         ext/plain....
```

Without this fix, what you'd see is something like:

```
09:44:39.965428 ac:bc:32:b6:29:67 > bc:14:01:57:0b:52, ethertype IPv4 (0x0800), length 464: 192.168.0.19.5060 > 192.168.0.1.5060: SIP: OPTIONS sip:YOmvsiCy@192.168.0.1 SIP/2.0
        0x0000:  4500 018c d431 0000 ff11 64ca c0a8 0013  E....1....d.....
        0x0010:  c0a8 0001 13c4 13c4 0178 0000 4f50 5449  .........x..OPTI
        0x0020:  4f4e 5320 7369 703a 594f 6d76 7369 4379  ONS.sip:YOmvsiCy
        0x0030:  4031 3932 2e31 3638 2e30 2e31 2053 4950  @192.168.0.1.SIP
        0x0040:  2f32 2e30 0d0a 5669 613a 2053 4950 2f32  /2.0..Via:.SIP/2
        0x0050:  2e30 2f55 4450 2031 3932 2e31 3638 2e30  .0/UDP.192.168.0
        0x0060:  2e31 393a 3530 3630 3b62 7261 6e63 683d  .19:5060;branch=
        0x0070:  5071 666e 715a 2e36 3935 3133 3434 3738  PqfnqZ.695134478
        0x0080:  363b 7270 6f72 743b 616c 6961 730d 0a46  6;rport;alias..F
        0x0090:  726f 6d3a 2073 6970 3a56 7977 7a74 5658  rom:.sip:VywztVX
        0x00a0:  4740 3139 322e 3136 382e 302e 3139 3a35  G@192.168.0.19:5
        0x00b0:  3036 303b 7461 673d 3635 3533 3833 3239  060;tag=65538329
        0x00c0:  0d0a 546f 3a20 7369 703a 5344 6f44 464c  ..To:.sip:SDoDFL
        0x00d0:  7361 4031 3932 2e31 3638 2e30 2e31 0d0a  sa@192.168.0.1..
        0x00e0:  4361 6c6c 2d49 443a 2033 3730 3738 3833  Call-ID:.3707883
        0x00f0:  3833 3040 3139 322e 3136 382e 302e 3139  830@192.168.0.19
        0x0100:  0d0a 4353 6571 3a20 3120 4f50 5449 4f4e  ..CSeq:.1.OPTION
        0x0110:  530d 0a43 6f6e 7461 6374 3a20 7369 703a  S..Contact:.sip:
        0x0120:  455a 5243 7552 7a6f 4031 3932 2e31 3638  EZRCuRzo@192.168
        0x0130:  2e30 2e31 393a 3530 3630 0d0a 436f 6e74  .0.19:5060..Cont
        0x0140:  656e 742d 4c65 6e67 7468 3a20 300d 0a4d  ent-Length:.0..M
        0x0150:  6178 2d46 6f72 7761 7264 733a 2032 300d  ax-Forwards:.20.
        0x0160:  0a55 7365 722d 4167 656e 743a 2050 4e5a  .User-Agent:.PNZ
        0x0170:  5747 644d 630d 0a41 6363 6570 743a 2074  WGdMc..Accept:.t
        0x0180:  6578 742f 706c 6169 6e0d 0a0d            ext/plain...
```

Note that the trailing `0a` is missing to properly terminate the SIP message.  Also, when viewed in wireshark (tcpdump hides this), the entire ethernet frame is the length of the original template before interpolation and padded by that missing trailing `0a` followed by nulls.  This may be interpreted as a bad frame due to the fram check seequence or something by some network gear