### PR TITLE
Accept additional synack RST responses, correct syn scan RST behavior

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -107,14 +107,22 @@ int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 	}
 	// validate tcp acknowledgement number
 	if (htonl(tcp->th_ack) != htonl(validation[0])+1) {
-		return 0;
+
+		// RSTs do not need to +1 the ack
+		if (tcp->th_flags & TH_RST) {
+			if (htonl(tcp->th_ack) != htonl(validation[0]) + 0) {
+				return 0;
+			}
+		} else {
+			return 0;
+		}
 	}
 	return 1;
 }
 
 void synscan_process_packet(const u_char *packet,
 		__attribute__((unused)) uint32_t len, fieldset_t *fs,
-        __attribute__((unused)) uint32_t *validation)
+		__attribute__((unused)) uint32_t *validation)
 {
 	struct ip *ip_hdr = (struct ip *)&packet[sizeof(struct ether_header)];
 	struct tcphdr *tcp = (struct tcphdr*)((char *)ip_hdr


### PR DESCRIPTION
Accepts additional packets as valid as part of the SYNACK scan module. This involves setting additional validation bits in the ACK Field (which we should have been doing to begin with) and checking them.

Also part of the PR is correcting how zmap validates RST packets for SYN scans. Per the RFC, in SYN-SENT you should accept SYN+0 as well as SYN+1 packets. We previously only accepted SYN+1

Rolled into this is fixing a few lines whitespace where spaces were used instead of tabs.