### PR TITLE
add missing header file for example forge-socket - lxj616

### DIFF
--- a/examples/forge-socket/forge_socket.h
+++ b/examples/forge-socket/forge_socket.h
@@ -1,0 +1,51 @@
+#ifndef _FORGE_H
+#define _FORGE_H
+
+#include <linux/types.h>
+
+#define SOCK_FORGE      9   /* new protocol */
+#define TCP_STATE       18  /* new TCP sockopt */
+
+struct tcp_state {
+	__be32      src_ip;
+	__be32      dst_ip;
+
+	__be16      sport;
+	__be16      dport;
+	__u32       seq;
+	__u32       ack;
+	__u32	    snd_una;	/* First byte we want an ack for */
+
+	__u8        tstamp_ok;
+	__u8        sack_ok;
+	__u8        wscale_ok;
+	__u8        ecn_ok;
+	__u8        snd_wscale;
+	__u8        rcv_wscale;
+
+	__u32       snd_wnd;
+	__u32       rcv_wnd;
+
+	__u32       ts_recent;  /* Timestamp to echo next. */
+	__u32       ts_val;     /* Timestamp to use next. */
+
+	__u32       mss_clamp;
+};
+
+
+#ifdef __KERNEL__
+int forge_setsockopt(struct sock *sk, int level, int optname,
+		char __user *optval, unsigned int optlen);
+int forge_getsockopt(struct sock *sk, int level, int optname,
+		char __user *optval, int __user *optlen);
+int forge_getsockopt_socket(struct socket *sock, int level, int optname,
+		char __user *optval, int __user *optlen)
+{
+	return forge_getsockopt(sock->sk, level, optname, optval, optlen);
+}
+struct sock *forge_csk_accept(struct sock *sk, int flags, int *err);
+#endif
+
+
+
+#endif


### PR DESCRIPTION
The header file is missing

```
alkaid@alkaid-CN15S:~/hides/zmap/examples/forge-socket$ make
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC   -c -o forge-socket.o forge-socket.c
forge-socket.c:24:26: fatal error: forge_socket.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'forge-socket.o' failed
make: *** [forge-socket.o] Error 1
```
fix - add header file

```
alkaid@alkaid-CN15S:~/hides/zmap/examples/forge-socket$ cp /tmp/forge_socket.h .
alkaid@alkaid-CN15S:~/hides/zmap/examples/forge-socket$ make
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC   -c -o forge-socket.o forge-socket.c
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC   -c -o xalloc.o ../../lib/xalloc.c
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC   -c -o logger.o ../../lib/logger.c
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC   -c -o lockfd.o ../../lib/lockfd.c
cc -I../../lib/ -I../../forge_socket -Wall -g -O2 -fstack-protector-all --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -fPIC forge-socket.o xalloc.o logger.o lockfd.o -o forge-socket -lpcap -levent -levent_extra -lm -Wl,-Bsymbolic-functions -Wl,-z,relro,-z,now
```
