### PR TITLE
Fix compatibility with newer PF_RING

### DIFF
--- a/src/recv-pfring.c
+++ b/src/recv-pfring.c
@@ -57,7 +57,8 @@ void recv_packets()
 		return;
 	}
 	// Successfully got a packet, now handle it
-	handle_packet(pf_buffer->len, pf_buffer->data);
+	uint8_t* pkt_buf = pfring_zc_pkt_buff_data(pf_buffer, pf_recv);
+	handle_packet(pf_buffer->len, pkt_buf);
 }
 
 int recv_update_stats(void)

--- a/src/send-pfring.h
+++ b/src/send-pfring.h
@@ -27,7 +27,7 @@ int send_run_init(sock_t socket)
 int send_packet(sock_t sock, void *buf, int len, uint32_t idx)
 {
 	sock.pf.buffers[idx]->len = len;
-	memcpy(sock.pf.buffers[idx]->data, buf, len);
+	memcpy(pfring_zc_pkt_buff_data(sock.pf.buffers[idx], sock.pf.queue), buf, len);
 	int ret;
 	do {
 		ret = pfring_zc_send_pkt(sock.pf.queue, &sock.pf.buffers[idx], 0);

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -46,8 +46,9 @@
 
 #ifdef PFRING
 #include <pfring_zc.h>
-static int32_t distrib_func(pfring_zc_pkt_buff *pkt, void *arg) {
+static int32_t distrib_func(pfring_zc_pkt_buff *pkt, pfring_zc_queue *in_queue, void *arg) {
 	(void) pkt;
+	(void) in_queue;
 	(void) arg;
 	return 0;
 }


### PR DESCRIPTION
This fixes the 10 Gig support to compile against PF_RING 6.2. It may also work
with newer versions. Specifically, it updates for the new type of the
pf_ring_distribution_func callback, and accounts for pk_ring_zc_pkt_buf no
longer having the `data` field.

Fixes #350