### PR TITLE
Handle invalid zblacklist input, arg to toggle printing

### DIFF
--- a/src/zblacklist.1
+++ b/src/zblacklist.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZBLACKLIST" "1" "September 2015" "zmap v2.1.1" "zblacklist"
+.TH "ZBLACKLIST" "1" "December 2016" "ZMap" "zblacklist"
 .
 .SH "NAME"
 \fBzblacklist\fR \- zmap IP blacklist tool
@@ -39,4 +39,8 @@ Don\'t deduplicate input addresses\. Default is false\.
 .TP
 \fB\-\-ignore\-blacklist\-errors\fR
 Ignore invalid entries in the blacklist\. Default is false\.
+.
+.TP
+\fB\-\-ignore\-input\-errors\fR
+Don\'t print invalid entries in the input\. Default is false\.
 

--- a/src/zblacklist.1.html
+++ b/src/zblacklist.1.html
@@ -94,13 +94,14 @@ subnets will be excluded.</p></dd>
 <dt><code>-v</code>, <code>--verbosity</code></dt><dd><p>Level of log detail (0-5, default=3)</p></dd>
 <dt><code>--no-duplicate-checking</code></dt><dd><p>Don't deduplicate input addresses. Default is false.</p></dd>
 <dt><code>--ignore-blacklist-errors</code></dt><dd><p>Ignore invalid entries in the blacklist. Default is false.</p></dd>
+<dt><code>--ignore-input-errors</code></dt><dd><p>Don't print invalid entries in the input. Default is false.</p></dd>
 </dl>
 
 
 
   <ol class='man-decor man-foot man foot'>
-    <li class='tl'>zmap v2.1.1</li>
-    <li class='tc'>September 2015</li>
+    <li class='tl'>ZMap</li>
+    <li class='tc'>December 2016</li>
     <li class='tr'>zblacklist(1)</li>
   </ol>
 

--- a/src/zblacklist.1.ronn
+++ b/src/zblacklist.1.ronn
@@ -35,3 +35,6 @@ IP addresses using a blacklist or whitelist.
 
   * `--ignore-blacklist-errors`:
     Ignore invalid entries in the blacklist. Default is false.
+
+  * `--ignore-input-errors`:
+    Don't print invalid entries in the input. Default is false.

--- a/src/zblacklist.c
+++ b/src/zblacklist.c
@@ -207,6 +207,10 @@ int main(int argc, char **argv)
 		struct in_addr addr;
 		if (!inet_aton(line, &addr)) {
 			log_warn("zblacklist", "invalid input address: %s", line);
+			if (!conf.ignore_input_errors) {
+				printf("%s", original);
+			}
+			continue;
 		}
 		if (conf.check_duplicates) {
 			if (pbm_check(seen, ntohl(addr.s_addr))) {

--- a/src/zblacklist.c
+++ b/src/zblacklist.c
@@ -66,7 +66,8 @@ struct zbl_conf {
 	char *whitelist_filename;
 	char *log_filename;
 	int check_duplicates;
-	int ignore_errors;
+	int ignore_blacklist_errors;
+	int ignore_input_errors;
 	int verbosity;
 	int disable_syslog;
 	//struct zbl_stats stats;
@@ -83,7 +84,8 @@ int main(int argc, char **argv)
 	conf.verbosity = 3;
 	memset(&conf, 0, sizeof(struct zbl_conf));
 	int no_dupchk_pres = 0;
-	conf.ignore_errors = 0;
+	conf.ignore_blacklist_errors = 0;
+	conf.ignore_input_errors = 0;
 
 	struct gengetopt_args_info args;
 	struct cmdline_parser_params *params;
@@ -126,7 +128,8 @@ int main(int argc, char **argv)
 	// Read the boolean flags
 	SET_BOOL(no_dupchk_pres, no_duplicate_checking);
 	conf.check_duplicates = !no_dupchk_pres;
-	SET_BOOL(conf.ignore_errors, ignore_blacklist_errors);
+	SET_BOOL(conf.ignore_blacklist_errors, ignore_blacklist_errors);
+	SET_BOOL(conf.ignore_input_errors, ignore_input_errors);
 	SET_BOOL(conf.disable_syslog, disable_syslog);
 
 	// initialize logging
@@ -169,7 +172,7 @@ int main(int argc, char **argv)
 	}
 
 	if (blacklist_init(conf.whitelist_filename, conf.blacklist_filename,
-			NULL, 0, NULL, 0, conf.ignore_errors)) {
+			NULL, 0, NULL, 0, conf.ignore_blacklist_errors)) {
 		log_fatal("zmap", "unable to initialize blacklist / whitelist");
 	}
 	// initialize paged bitmap

--- a/src/zbopt.ggo.in
+++ b/src/zbopt.ggo.in
@@ -25,6 +25,8 @@ option "no-duplicate-checking"    - "Don't deduplicate IP addresses (default fal
     optional
 option "ignore-blacklist-errors"  - "Ignore invalid entires in the blacklist/whitelist (default false)"
     optional
+option "ignore-input-errors"      - "Don't print invalid entires in the input (default false)"
+    optional
 option "disable-syslog"           - "Disables logging messages to syslog"
     optional
 


### PR DESCRIPTION
Closes #381

Previously we were reading an uninitialized in_addr struct resulting
in different behavior depending on unrelated options.

We now short circuit when we hit an invalid entry (preventing reading
uninitialized memory, and control printing with a new argument.

I also renamed the existing conf variable from ignore_errors to ignore_blacklist_errors, to match convention everywhere else.