### PR TITLE
Replace version string with git commit information for non-release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,6 @@ option(WITH_WERROR "Build with -Werror" OFF)
 option(WITH_PFRING "Build with PF_RING ZC for send (10 GigE)" OFF)
 option(FORCE_CONF_INSTALL "Overwrites existing configuration files at install" OFF)
 
-if("${ZMAP_VERSION}" STREQUAL "DEVELOPMENT")
-    set(GIT_CMD "git")
-    set(GIT_ARGS "log" "-n" "1" "--pretty=format:%h - %ad")
-    execute_process(COMMAND ${GIT_CMD} ${GIT_ARGS}
-        RESULT_VARIABLE GIT_RESULT
-        OUTPUT_VARIABLE GIT_COMMIT)
-    if (GIT_RESULT)
-        set (GIT_COMMIT "UNKNOWN")
-    endif()
-    set(ZMAP_VERSION "Development Build. Commit ${GIT_COMMIT}")
-endif()
-
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(USING_CLANG "YES")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(ZMAP C)
-set(ZMAP_VERSION 2.1.1)
+set(ZMAP_VERSION DEVELOPMENT) # Change DEVELOPMENT to version number for release
 
 option(WITH_REDIS "Build with support for Redis DB" OFF)
 option(WITH_MONGO "Build with support for MongoDB" OFF)
@@ -10,6 +10,18 @@ option(RESPECT_INSTALL_PREFIX_CONFIG "Respect CMAKE_INSTALL_PREFIX for /etc" OFF
 option(WITH_WERROR "Build with -Werror" OFF)
 option(WITH_PFRING "Build with PF_RING ZC for send (10 GigE)" OFF)
 option(FORCE_CONF_INSTALL "Overwrites existing configuration files at install" OFF)
+
+if("${ZMAP_VERSION}" STREQUAL "DEVELOPMENT")
+    set(GIT_CMD "git")
+    set(GIT_ARGS "log" "-n" "1" "--pretty=format:%h - %ad")
+    execute_process(COMMAND ${GIT_CMD} ${GIT_ARGS}
+        RESULT_VARIABLE GIT_RESULT
+        OUTPUT_VARIABLE GIT_COMMIT)
+    if (GIT_RESULT)
+        set (GIT_COMMIT "UNKNOWN")
+    endif()
+    set(ZMAP_VERSION "Development Build. Commit ${GIT_COMMIT}")
+endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(USING_CLANG "YES")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,16 +144,16 @@ else()
 endif()
 
 # Set configure time zmap version
-configure_file(topt.ggo.in topt.ggo @ONLY)
-configure_file(zbopt.ggo.in zbopt.ggo @ONLY)
-configure_file(zitopt.ggo.in zitopt.ggo @ONLY)
-configure_file(zopt.ggo.in zopt.ggo @ONLY)
+configure_file(topt.ggo.in ${CMAKE_BINARY_DIR}/src/topt.ggo @ONLY)
+configure_file(zbopt.ggo.in ${CMAKE_BINARY_DIR}/src/zbopt.ggo @ONLY)
+configure_file(zitopt.ggo.in ${CMAKE_BINARY_DIR}/src/zitopt.ggo @ONLY)
+configure_file(zopt.ggo.in ${CMAKE_BINARY_DIR}/src/zopt.ggo @ONLY)
 # Additional ggo.in's should be added here and CMakeVersion.txt
 
 # This sets a *build* time dependency that checks git
 if("${ZMAP_VERSION}" STREQUAL "DEVELOPMENT")
     add_custom_target(git_versioning ALL
-        COMMAND ${CMAKE_COMMAND} -P CMakeVersion.txt 
+        COMMAND ${CMAKE_COMMAND} -D PATH:STRING="${CMAKE_BINARY_DIR}/src" -P CMakeVersion.txt 
         )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,10 +143,19 @@ else()
     set(ZTESTSOURCES ${ZTESTSOURCES} recv-pcap.c)
 endif()
 
+# Set configure time zmap version
 configure_file(topt.ggo.in topt.ggo @ONLY)
 configure_file(zbopt.ggo.in zbopt.ggo @ONLY)
 configure_file(zitopt.ggo.in zitopt.ggo @ONLY)
 configure_file(zopt.ggo.in zopt.ggo @ONLY)
+# Additional ggo.in's should be added here and CMakeVersion.txt
+
+# This sets a *build* time dependency that checks git
+if("${ZMAP_VERSION}" STREQUAL "DEVELOPMENT")
+    add_custom_target(git_versioning ALL
+        COMMAND ${CMAKE_COMMAND} -P CMakeVersion.txt 
+        )
+endif()
 
 add_custom_command(OUTPUT zopt.h
     COMMAND gengetopt -C --no-help --no-version --unamed-opts=SUBNETS -i "${CMAKE_CURRENT_BINARY_DIR}/zopt.ggo" -F "${CMAKE_CURRENT_BINARY_DIR}/zopt"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,10 +143,10 @@ else()
     set(ZTESTSOURCES ${ZTESTSOURCES} recv-pcap.c)
 endif()
 
-configure_file(topt.ggo.in ${CMAKE_BINARY_DIR}/src/topt.ggo @ONLY)
-configure_file(zbopt.ggo.in ${CMAKE_BINARY_DIR}/src/zbopt.ggo @ONLY)
-configure_file(zitopt.ggo.in ${CMAKE_BINARY_DIR}/src/zitopt.ggo @ONLY)
-configure_file(zopt.ggo.in ${CMAKE_BINARY_DIR}/src/zopt.ggo @ONLY)
+configure_file(topt.ggo.in topt.ggo @ONLY)
+configure_file(zbopt.ggo.in zbopt.ggo @ONLY)
+configure_file(zitopt.ggo.in zitopt.ggo @ONLY)
+configure_file(zopt.ggo.in zopt.ggo @ONLY)
 
 add_custom_command(OUTPUT zopt.h
     COMMAND gengetopt -C --no-help --no-version --unamed-opts=SUBNETS -i "${CMAKE_CURRENT_BINARY_DIR}/zopt.ggo" -F "${CMAKE_CURRENT_BINARY_DIR}/zopt"

--- a/src/CMakeVersion.txt
+++ b/src/CMakeVersion.txt
@@ -8,7 +8,7 @@ execute_process(COMMAND ${GIT_CMD} ${GIT_ARGS}
     endif()
 set(ZMAP_VERSION "Development Build. Commit ${GIT_COMMIT}")
 
-configure_file(topt.ggo.in topt.ggo @ONLY)
-configure_file(zbopt.ggo.in zbopt.ggo @ONLY)
-configure_file(zitopt.ggo.in zitopt.ggo @ONLY)
-configure_file(zopt.ggo.in zopt.ggo @ONLY)
+configure_file(topt.ggo.in "${PATH}/topt.ggo" @ONLY)
+configure_file(zbopt.ggo.in "${PATH}/zbopt.ggo" @ONLY)
+configure_file(zitopt.ggo.in "${PATH}/zitopt.ggo" @ONLY)
+configure_file(zopt.ggo.in "${PATH}/zopt.ggo" @ONLY)

--- a/src/CMakeVersion.txt
+++ b/src/CMakeVersion.txt
@@ -1,0 +1,14 @@
+set(GIT_CMD "git")
+set(GIT_ARGS "log" "-n" "1" "--pretty=format:%h - %ad")
+execute_process(COMMAND ${GIT_CMD} ${GIT_ARGS}
+    RESULT_VARIABLE GIT_RESULT
+    OUTPUT_VARIABLE GIT_COMMIT)
+    if (GIT_RESULT)
+        set (GIT_COMMIT "UNKNOWN")
+    endif()
+set(ZMAP_VERSION "Development Build. Commit ${GIT_COMMIT}")
+
+configure_file(topt.ggo.in topt.ggo @ONLY)
+configure_file(zbopt.ggo.in zbopt.ggo @ONLY)
+configure_file(zitopt.ggo.in zitopt.ggo @ONLY)
+configure_file(zopt.ggo.in zopt.ggo @ONLY)


### PR DESCRIPTION
Switching back to the classic version can be done by changing the ZMAP_VERSION variable in /CMakeLists.txt to a version number and calling 'make'.