### PR TITLE
only skip CSV header row when default output module not based on number of columns

### DIFF
--- a/src/output_modules/module_csv.c
+++ b/src/output_modules/module_csv.c
@@ -40,7 +40,7 @@ int csv_init(struct state_conf *conf, char **fields, int fieldlens)
 		file = stdout;
 		log_info("csv", "no output file selected, will use stdout");
 	}
-	if (fieldlens > 1 && file) {
+	if (file && strcmp(conf->output_module_name, "default")) {
 		log_debug("csv", "more than one field, will add headers");
 		for (int i=0; i < fieldlens; i++) {
 			if (i) {

--- a/src/state.h
+++ b/src/state.h
@@ -78,6 +78,7 @@ struct state_conf {
 	uint8_t total_shards;
 	int packet_streams;
 	struct probe_module *probe_module;
+	char *output_module_name;
 	struct output_module *output_module;
 	char *probe_args;
 	char *output_args;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -380,6 +380,7 @@ int main(int argc, char *argv[])
 				args.output_module_arg);
 		}
 	}
+	zconf.output_module_name = strdup(args.output_module_arg);
 	zconf.probe_module = get_probe_module_by_name(args.probe_module_arg);
 	if (!zconf.probe_module) {
 		log_fatal("zmap", "specified probe module (%s) does not exist\n",


### PR DESCRIPTION
This closes #445.