### PR TITLE
Various minor improvements in readme/install/contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ ZMap accepts contributions in the form of issues and pull requests. In either
 case, before posting please [search](https://github.com/zmap/zmap/issues) to see
 if your change or bug report has been addressed previously.
 
-[INSTALL](https://github.com/zmap/zmap/blob/master/INSTALL.md#building-from-source)
-provides guidance on building ZMap from source.
+[INSTALL](INSTALL.md#building-from-source) provides guidance on building ZMap
+from source.
 
 Developing
 ----------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@ Contributing to ZMap
 ====================
 
 ZMap accepts contributions in the form of issues and pull requests. In either
-case, please [search](https://github.com/zmap/zmap/issues) to see if it has been
-addressed previously before posting.
+case, before posting please [search](https://github.com/zmap/zmap/issues) to see
+if your change or bug report has been addressed previously.
 
 [INSTALL](https://github.com/zmap/zmap/blob/master/INSTALL.md#building-from-source)
-provides guidance on buildign ZMap from source.
+provides guidance on building ZMap from source.
 
 Developing
 ----------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Reviewing
 
 - All pull-requests should be squash-merged into master.
 
-- When squash-merging, put the PR number in the commit title. Github does this
+- When squash-merging, put the PR number in the commit title. GitHub does this
   automatically in the web interface.  Condense the commit messages down to a
   single messsage; often this can just be the commit message from the first
   commit in a PR. Follow the commit formatting guidelines [here][guidelines].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,12 @@
-CONTRIBUTING
-============
+Contributing to ZMap
+====================
 
 ZMap accepts contributions in the form of issues and pull requests. In either
-case, please search to see if it has been addressed previously before posting.
+case, please [search](https://github.com/zmap/zmap/issues) to see if it has been
+addressed previously before posting.
+
+[INSTALL](https://github.com/zmap/zmap/blob/master/INSTALL.md#building-from-source)
+provides guidance on buildign ZMap from source.
 
 Developing
 ----------
@@ -14,7 +18,6 @@ Developing
 - Before submitting a PR, please rebase/squash your commits down to a single
   commit. Follow these [commit message guidelines][guidelines], especially with
   regard to formatting.
-
 
 Reviewing
 ---------
@@ -31,4 +34,3 @@ Reviewing
 
 [kernelguide]: https://www.kernel.org/doc/Documentation/process/coding-style.rst
 [guidelines]: https://github.com/torvalds/subsurface-for-dirk/blob/master/README#L92
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,40 +1,21 @@
-## Installing/Building ZMap
+# Installing and Building ZMap
 
-### Installing from Package Manager
+## Installing via Package Manager
 
-ZMap operates on GNU/Linux, Mac OS, and BSD. The latest stable version (v2.1.1)
+ZMap operates on GNU/Linux, macOS, and BSD. The latest stable version (v2.1.1)
 can be installed using most OS package managers:
 
-Fedora 19+ or EPEL 6+:
-  ```sh
-  yum install zmap
-  ```
+| OS                                        |                         |
+| ----------------------------------------- | ----------------------- |
+| Fedora 19+ or EPEL 6+                     | `sudo yum install zmap` |
+| Debian 8+ or Ubuntu 14.04+                | `sudo apt install zmap` |
+| Gentoo                                    | `sudo emerge zmap`      |
+| macOS (using [Homebrew](https://brew.sh)) | `brew install zmap`     |
+| Arch Linux                                | `sudo pacman -S zmap`   |
 
-Debian 8+, Ubuntu 14.04+:
-  ```sh
-  sudo apt install zmap
-  ```
+## Building from Source
 
-Arch Linux:
-  ```sh
-  pacman -S zmap
-  ```
-
-Gentoo:
-  ```sh
-  sudo emerge zmap
-  ```
-
-Mac OS (brew):
-  ```sh
-  brew install zmap
-  ```
-
-### Building from Source
-
-It is also possible to build ZMap from source.
-
-#### Installing ZMap Dependencies
+### Installing ZMap Dependencies
 
 ZMap has the following dependencies:
 
@@ -42,69 +23,73 @@ ZMap has the following dependencies:
   - [GMP](http://gmplib.org/) - Free library for arbitrary precision arithmetic
   - [gengetopt](http://www.gnu.org/software/gengetopt/gengetopt.html) - Command line option parsing for C programs
   - [libpcap](http://www.tcpdump.org/) - Famous user-level packet capture library
-  - [flex](http://flex.sourceforge.net/) and [byacc](http://invisible-island.net/byacc/) - Output filter lexer and parser generator.
+  - [flex](http://flex.sourceforge.net/) and [byacc](http://invisible-island.net/byacc/) - Output filter lexer and parser generator
   - [json-c](https://github.com/json-c/json-c/) - JSON implementation in C
   - [libunistring](https://www.gnu.org/software/libunistring/) - Unicode string library for C
-  - [libdnet](https://github.com/dugsong/libdnet) - (Mac Only) Gateway and route detection.
+  - [libdnet](https://github.com/dugsong/libdnet) - (macOS Only) Gateway and route detection
 
-In addition, you can get following packages to get further functionalities:
+In addition, the following optional packages enable optional ZMap functionality:
 
   - [hiredis](https://github.com/redis/hiredis) - RedisDB support in C
-  - [mongo-c-driver](https://github.com/mongodb/mongo-c-driver/) - MongoDB support in C
 
-You can install these dependencies with the following commands
+Install the required dependencies with the following commands.
 
-* On Debian-based systems by running:
+* On Debian-based systems (including Ubuntu):
    ```sh
    sudo apt-get install build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config libunistring-dev
    ```
 
-* On RHEL- and Fedora-based systems by running:
+* On RHEL- and Fedora-based systems (including CentOS):
    ```sh
    sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel
    ```
 
-* On Mac OS systems using [Homebrew](http://brew.sh/):
+* On macOS systems (using [Homebrew](http://brew.sh/)):
   ```sh
   brew install pkg-config cmake gmp gengetopt json-c byacc libdnet libunistring
   ```
 
-#### Building and Installing ZMap
+### Building and Installing ZMap
 
-Once these prerequisites have been installed, ZMap can be compiled
-by running:
+Once these prerequisites are installed, ZMap can be compiled by running:
   ```sh
   cmake .
   make -j4
   ```
 
-and installed by running:
-  ```sh
-  sudo make install
-  ```
+and then installed via `sudo make install`.
 
-## Miscellaneous Notes
+### Development Notes
 
 - Enabling development turns on debug symbols, and turns off optimizations.
 Release builds should be built with `-DENABLE_DEVELOPMENT=OFF`.
 
-- Enabling `log_trace`:w can have a major performance impact and should not be used
+- Enabling `log_trace` can have a major performance impact and should not be used
 except during early development. Release builds should be built with `-DENABLE_LOG_TRACE=OFF`.
 
-- Redis support is not enabled by default. If you want to use ZMap with Redis, you will first need to install hiredis. Then run cmake with `-DWITH_REDIS=ON`. Debian has packaged it as `libhiredis-dev`, Fedora and RHEL have packaged it as `hiredis-devel`.
+- Redis support is not enabled by default. If you want to use ZMap with Redis,
+you will first need to install hiredis. Then run cmake with `-DWITH_REDIS=ON`.
+Debian/Ubuntu has packaged hiredis as `libhiredis-dev`; Fedora and RHEL/CentOS
+have packaged it as `hiredis-devel`.
 
-- MongoDB support is not enabled by default. If you want to use ZMap with MongoDB, you will first need to install mongo-c-driver. Then run cmake with `-DWITH_MONGO=ON`.
+- Building packages for some systems like Fedora and RHEL requires a user-definable
+directory (buildroot) to put files. The way to respect this prefix is to run cmake
+with `-DRESPECT_INSTALL_PREFIX_CONFIG=ON`.
 
-- Building packages for some systems like Fedora and RHEL requires a user-definable directory (buildroot) to put files, the conducive way to respect prefix is to run cmake with `-DRESPECT_INSTALL_PREFIX_CONFIG=ON`.
+- Manpages (and their HTML representations) are generated from the `.ronn` source
+files in the repository, using the [ronn](https://github.com/rtomayko/ronn) tool.
+This does not happen automatically as part of the build process; to regenerate the
+man pages you'll need to run `make manpages`. This target assumes that `ronn` is
+in your PATH.
 
-- Manpages (and their HTML representations) are generated from the `.ronn` source files in the repository, using the [ronn](https://github.com/rtomayko/ronn) tool. This does not happen automatically as part of the build process; to regenerate the man pages you'll need to run `make manpages`. This target assumes that `ronn` is in your PATH.
+- Building with some versions of CMake may fail with `unable to find parser.h`.
+If this happens, try updating CMake. If it still fails, don't clone ZMap into a
+path that contains the string `.com`, and try again.
 
-- Building with some versions of CMake may fail with `unable to find parser.h`. If this happens, try updating CMake. If it still fails, don't clone ZMap into a path that contains the string `.com`, and try again.
-
-- ZMap may be installed to an alternative directory, with the `CMAKE_INSTALL_PREFIX` option. For example, run
-    ```
+- ZMap may be installed to an alternative directory, with the `CMAKE_INSTALL_PREFIX`
+option. For example, to install it in `$HOME/opt` run
+    ```sh
     cmake -DCMAKE_INSTALL_PREFIX=$HOME/opt .
     make -j4
     make install
     ```
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ZMap: The Internet Scanner
 ZMap is a fast single packet network scanner designed for Internet-wide network
 surveys. On a typical desktop computer with a gigabit Ethernet connection, ZMap
 is capable scanning the entire public IPv4 address space in under 45 minutes. With
-a 10gigE connection and [PF_RING](http://www.ntop.org/products/packet-capture/pf_ring/pf_ring-zc-zero-copy/),
+a 10gigE connection and [PF_RING](http://www.ntop.org/products/packet-capture/pf_ring/),
 ZMap can scan the IPv4 address space in under 5 minutes.
 
 ZMap operates on GNU/Linux, macOS, and BSD. ZMap currently has full implemented

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ operating systems:
 Usage
 -----
 
-A guide to using ZMap is found in our [Github Wiki](https://github.com/zmap/zmap/wiki).
+A guide to using ZMap is found in our [GitHub Wiki](https://github.com/zmap/zmap/wiki).
 
 License and Copyright
 ---------------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ZMap's sister project that performs application-layer handshakes.
 Installation
 ------------
 
-The latest stable release of ZMap is version 2.1.1 and supports Linux, Mac OS, and
+The latest stable release of ZMap is version 2.1.1 and supports Linux, macOS, and
 BSD. It can be installed through the built-in package managers on the following
 operating systems:
 

--- a/README.md
+++ b/README.md
@@ -5,41 +5,37 @@ ZMap: The Internet Scanner
 
 ZMap is a fast single packet network scanner designed for Internet-wide network
 surveys. On a typical desktop computer with a gigabit Ethernet connection, ZMap
-is capable scanning the entire public IPv4 address space in under 45 minutes.
-With a 10gigE connection and PF_RING, ZMap can scan the IPv4 address space in
-under 5 minutes.
+is capable scanning the entire public IPv4 address space in under 45 minutes. With
+a 10gigE connection and [PF_RING](http://www.ntop.org/products/packet-capture/pf_ring/pf_ring-zc-zero-copy/),
+ZMap can scan the IPv4 address space in under 5 minutes.
 
-ZMap operates on GNU/Linux, Mac OS, and BSD. ZMap currently has fully
-implemented probe modules for TCP SYN scans, ICMP, DNS queries, UPnP, BACNET,
-and can send a large number of UDP probes. If you are looking to do more
-involved scans, e.g., banner grab or TLS handshake, take a look at ZGrab
-(https://github.com/zmap/zgrab), ZMap's sister project that does
-application-layer handshakes.
+ZMap operates on GNU/Linux, macOS, and BSD. ZMap currently has full implemented
+probe modules for TCP SYN scans, ICMP, DNS queries, UPnP, BACNET, and can send a
+large number of UDP probes. If you are looking to do more involved scans, e.g.,
+banner grab or TLS handshake, take a look at [ZGrab](https://github.com/zmap/zgrab),
+ZMap's sister project that performs application-layer handshakes.
 
 Installation
 ------------
 
-The latest stable release of ZMap is version 2.1.1 and supports Linux, Mac OS,
-and BSD. It can be installed through the built-in package managers on the
-following operating systems:
+The latest stable release of ZMap is version 2.1.1 and supports Linux, Mac OS, and
+BSD. It can be installed through the built-in package managers on the following
+operating systems:
 
-Debian or Ubuntu: `sudo apt-get install zmap`
+| OS                                        |                             |
+| ----------------------------------------- | --------------------------- |
+| Debian or Ubuntu                          | `sudo apt install zmap`     |
+| Fedora, CentOS, and RHEL                  | `sudo yum install zmap`     |
+| Gentoo                                    | `sudo emerge zmap`          |
+| macOS (using [Homebrew](https://brew.sh)) | `brew install zmap`         |
+| Arch Linux                                | `sudo pacman -S zmap`       |
 
-Fedora, CentOS, and RHEL: `sudo yum install zmap`
+**Instructions on building ZMap from source** can be found in [INSTALL](INSTALL.md).
 
-Gentoo: `sudo emerge zmap`
+Usage
+-----
 
-Mac OS (using [Homebrew](https://brew.sh)): `brew install zmap`
-
-Arch Linux: Available through AUR
-
-Instructions on building ZMap from source can be found in [INSTALL](https://github.com/zmap/zmap/blob/master/INSTALL.md).
-
-Using ZMap
-----------
-
-There is information on how to use ZMap in our [Github Wiki](https://github.com/zmap/zmap/wiki).
-
+A guide to using ZMap is found in our [Github Wiki](https://github.com/zmap/zmap/wiki).
 
 License and Copyright
 ---------------------


### PR DESCRIPTION
It'll be easiest just to read the Markdown-rendered versions of these files:

* https://github.com/zmap/zmap/blob/cdz/doc-edits/README.md
* https://github.com/zmap/zmap/blob/cdz/doc-edits/INSTALL.md
* https://github.com/zmap/zmap/blob/cdz/doc-edits/CONTRIBUTING.md

Notably, I removed Mongo from the docs since we're removing it in 3.0.