### PR TITLE
Fix packet rate limiting in send.c under specific conditions. Harden send.c

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -271,7 +271,6 @@ int send_run(sock_t st, shard_t *s)
 			last_time = now();
 		}
 	}
-	//printf("XXX Starting: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 	// Get the initial IP to scan.
 	uint32_t current_ip = shard_get_cur_ip(s);
 

--- a/src/send.c
+++ b/src/send.c
@@ -243,8 +243,8 @@ int send_run(sock_t st, shard_t *s)
 	pthread_mutex_unlock(&send_mutex);
 
 	// adaptive timing to hit target rate
-	uint32_t count = 0;
-	uint32_t last_count = count;
+	uint64_t count = 0;
+	uint64_t last_count = count;
 	double last_time = now();
 	uint32_t delay = 0;
 	int interval = 0;

--- a/src/send.c
+++ b/src/send.c
@@ -314,7 +314,7 @@ int send_run(sock_t st, shard_t *s)
 					;
 				if (!interval || (count % interval == 0)) {
 					double t = now();
-					assert(count == 0 || count > last_count);
+					assert(count > last_count);
 					assert(t > last_time);
 					delay *= (double)(count - last_count) /
 						 (t - last_time) /

--- a/src/send.c
+++ b/src/send.c
@@ -271,7 +271,7 @@ int send_run(sock_t st, shard_t *s)
 			last_time = now();
 		}
 	}
-
+	//printf("XXX Starting: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 	// Get the initial IP to scan.
 	uint32_t current_ip = shard_get_cur_ip(s);
 
@@ -314,12 +314,17 @@ int send_run(sock_t st, shard_t *s)
 				for (vi = delay; vi--;)
 					;
 				if (!interval || (count % interval == 0)) {
+					//printf("XXX Adjust, pre: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 					double t = now();
+					assert(count == 0 || count > last_count);
+					assert(t > last_time);
 					delay *= (double)(count - last_count) /
 						 (t - last_time) /
 						 (zconf.rate / zconf.senders);
+					//printf("XXX Adjust, mid: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 					if (delay < 1)
 						delay = 1;
+					//printf("XXX Adjust, post: rate: %u, interval: %u, delay: %u\n\n", zconf.rate, interval, delay);
 					last_count = count;
 					last_time = t;
 				}

--- a/src/send.c
+++ b/src/send.c
@@ -296,7 +296,7 @@ int send_run(sock_t st, shard_t *s)
 	while (1) {
 		// Adaptive timing delay
 		send_rate = (double)zconf.rate / zconf.senders;
-		if (delay > 0) {
+		if (count && delay > 0) {
 			if (send_rate < slow_rate) {
 				double t = now();
 				double last_rate = (1.0 / (t - last_time));
@@ -314,17 +314,14 @@ int send_run(sock_t st, shard_t *s)
 				for (vi = delay; vi--;)
 					;
 				if (!interval || (count % interval == 0)) {
-					//printf("XXX Adjust, pre: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 					double t = now();
 					assert(count == 0 || count > last_count);
 					assert(t > last_time);
 					delay *= (double)(count - last_count) /
 						 (t - last_time) /
 						 (zconf.rate / zconf.senders);
-					//printf("XXX Adjust, mid: rate: %u, interval: %u, delay: %u\n", zconf.rate, interval, delay);
 					if (delay < 1)
-						delay = 1;
-					//printf("XXX Adjust, post: rate: %u, interval: %u, delay: %u\n\n", zconf.rate, interval, delay);
+						log_fatal("send", "send rate exceeds system capabilities");
 					last_count = count;
 					last_time = t;
 				}


### PR DESCRIPTION
(Note: This branch has a bunch of debug and partial commits in it. Once approved let me squash and edit the commit msg down plz.)

This PR fixes a number of issues:

* `count` and `last_count` were type `uint32_t`. When sending multiple packets (`-P`) this could lead to overflow. They are now `uint64_t`
* We implicitly relied on `count > last_count` and `time > last_time`. These are now assertions (that would have caught the overflow above)
* Our carefully calculated `delay` (used for busy waiting) is thrown away on the first iteration through the loop due to a startup error (`count == 0`). This caused delay to begin at `1` and cause a send spike. This is fixed by not entering the delay adjustment clause on startup (`count == 0`)
* The behavior of our delay calculation code is... problematic. If it ever converges to `delay == 1` and `rate` is set to greater than roughly `1/2 MAX`, where MAX is the max rate the system can send at, we lose control of the loop and emit packets at a rate beyond `rate`, never leaving `delay == 1`. Normally, this shouldn't matter, except when `delay` goes to 1 by mistake (or with the bug above). To harden against this, we now `log_fatal` if `delay -> 1`, both as a precaution to prevent emitting packets faster than `rate` (in the case of a bug or a momentary hiccup) but also as a feedback feature, as if you naturally go to `delay -> 1` it means you've specified a `rate` the hardware can't support.