### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,34 @@
+####
+# A Docker container for running zmap
+#
+# To build, beware of caching and:
+#
+#   * If you wish to build current master
+#
+#        docker build -t zmap_ubuntu -f Dockerfile .
+#
+#   * If you wisht to build a specific commit, use the ZMAP_COMMIT build argument.
+#
+#        docker build -t zmap_ubuntu -f Dockerfile --build-arg ZMAP_COMMIT=<your commit> .
+#
+# To run:
+#
+#     docker run  -it --rm --net=host zmap_ubuntu <zmap args>
+####
+
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get -y upgrade
+ARG ZMAP_COMMIT=master
+ENV ZMAP_COMMIT ${ZMAP_COMMIT}
+
+RUN apt-get -qq update && apt-get -qqy upgrade
 # install zmap build dependencies
 RUN apt-get -qqy install build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config libunistring-dev wget unzip
-# install zmap+Docker specific things
+# install zmap+Docker specific things, currently just dumb-init, which allows
+# us to more easily send signals to zmap, for example by allowing ctrl-c of
+# a running container and zmap will stop.
 RUN apt-get -qqy install python-dev python-pip
 RUN pip install dumb-init
-RUN wget -q https://github.com/zmap/zmap/archive/abc41b78ef97f90d951b7cb87329491a610ea7e8.zip && unzip -q abc41b78ef97f90d951b7cb87329491a610ea7e8.zip && cd zmap-abc41b78ef97f90d951b7cb87329491a610ea7e8 && (cmake . && make -j4 && make install) 2>&1
+RUN wget -q https://github.com/zmap/zmap/archive/${ZMAP_COMMIT}.zip && unzip -q ${ZMAP_COMMIT}.zip && cd zmap-${ZMAP_COMMIT} && (cmake . && make -j4 && make install) 2>&1 > /dev/null
 
 ENTRYPOINT ["dumb-init", "/usr/local/sbin/zmap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get -y upgrade
+# install zmap build dependencies
+RUN apt-get -qqy install build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config libunistring-dev wget unzip
+# install zmap+Docker specific things
+RUN apt-get -qqy install python-dev python-pip
+RUN pip install dumb-init
+RUN wget -q https://github.com/zmap/zmap/archive/abc41b78ef97f90d951b7cb87329491a610ea7e8.zip && unzip -q abc41b78ef97f90d951b7cb87329491a610ea7e8.zip && cd zmap-abc41b78ef97f90d951b7cb87329491a610ea7e8 && (cmake . && make -j4 && make install) 2>&1
+
+ENTRYPOINT ["dumb-init", "/usr/local/sbin/zmap"]


### PR DESCRIPTION
This adds a simple Dockerfile for building and running zmap in a Docker container, which may be advantageous for a number of reasons.  

Examples for building and running the container are in the Dockerfile.  Beware that this may take a while for the first build.