### PR TITLE
Clarify/improve rate and bandwidth-based comments and logging

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -135,15 +135,12 @@ iterator_t *send_init(void)
 			    "global initialization for probe module failed.");
 		}
 	}
-	// concert specified bandwidth to packet rate
+	// convert specified bandwidth to packet rate
 	if (zconf.bandwidth > 0) {
 		size_t pkt_len = zconf.probe_module->packet_length;
 		pkt_len *= 8;
-		pkt_len += 8 * 24; // 7 byte MAC preamble, 1 byte Start frame,
-		// 4 byte CRC, 12 byte inter-frame gap
-		if (pkt_len < 84 * 8) {
-			pkt_len = 84 * 8;
-		}
+		// 7 byte MAC preamble, 1 byte Start frame, 4 byte CRC, 12 byte inter-frame gap
+		pkt_len += 8 * 24;
 		// rate is a uint32_t so, don't overflow
 		if (zconf.bandwidth / pkt_len > 0xFFFFFFFFu) {
 			zconf.rate = 0;
@@ -159,8 +156,8 @@ iterator_t *send_init(void)
 			}
 		}
 		log_debug("send",
-			  "using bandwidth %lu bits/s, rate set to %d pkt/s",
-			  zconf.bandwidth, zconf.rate);
+			  "using bandwidth %lu bits/s for %zu bit probe, rate set to %d pkt/s",
+			  zconf.bandwidth, pkt_len, zconf.rate);
 	}
 	// Get the source hardware address, and give it to the probe
 	// module

--- a/src/send.c
+++ b/src/send.c
@@ -141,6 +141,10 @@ iterator_t *send_init(void)
 		pkt_len *= 8;
 		// 7 byte MAC preamble, 1 byte Start frame, 4 byte CRC, 12 byte inter-frame gap
 		pkt_len += 8 * 24;
+		// adjust calculated length if less than the minimum size of an ethernet frame
+		if (pkt_len < 84 * 8) {
+			pkt_len = 84 * 8;
+		}
 		// rate is a uint32_t so, don't overflow
 		if (zconf.bandwidth / pkt_len > 0xFFFFFFFFu) {
 			zconf.rate = 0;
@@ -156,8 +160,8 @@ iterator_t *send_init(void)
 			}
 		}
 		log_debug("send",
-			  "using bandwidth %lu bits/s for %zu bit probe, rate set to %d pkt/s",
-			  zconf.bandwidth, pkt_len, zconf.rate);
+			  "using bandwidth %lu bits/s for %zu byte probe, rate set to %d pkt/s",
+			  zconf.bandwidth, pkt_len/8, zconf.rate);
 	}
 	// Get the source hardware address, and give it to the probe
 	// module


### PR DESCRIPTION
In #488 I stumbled with what I thought was a bug.  It isn't.  This PR is the result, which cleans up some comments in this regard and improves the debug output, which I've been using to help understand rate issues.