### PR TITLE
fixing up warnings that have been showing up on linux systems

### DIFF
--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -584,7 +584,7 @@ static int dns_global_initialize(struct state_conf *conf)
 	qtypes = xmalloc(sizeof(uint16_t) * num_questions);
 
 	char *qtype_str = NULL;
-	char *domains[num_questions];
+	char **domains = (char**) xmalloc(sizeof(char *) * num_questions);
 
 	for (int i = 0; i < num_questions; i++) {
 		domains[i] = (char *)default_domain;

--- a/src/topt_compat.c
+++ b/src/topt_compat.c
@@ -1,6 +1,6 @@
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 6
+#elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/topt_compat.c
+++ b/src/topt_compat.c
@@ -1,6 +1,8 @@
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 4
+#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#elif __GNUC_MINOR__ >= 4 
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/zbopt_compat.c
+++ b/src/zbopt_compat.c
@@ -8,7 +8,7 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 6
+#elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/zbopt_compat.c
+++ b/src/zbopt_compat.c
@@ -8,6 +8,8 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
+#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif

--- a/src/zitopt_compat.c
+++ b/src/zitopt_compat.c
@@ -8,7 +8,7 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 6
+#elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/zitopt_compat.c
+++ b/src/zitopt_compat.c
@@ -8,6 +8,8 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
+#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif

--- a/src/zopt_compat.c
+++ b/src/zopt_compat.c
@@ -8,7 +8,7 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 6
+#elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/zopt_compat.c
+++ b/src/zopt_compat.c
@@ -8,6 +8,8 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
+#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif

--- a/src/ztopt_compat.c
+++ b/src/ztopt_compat.c
@@ -8,7 +8,7 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
-#elif __GNUC_MINOR__ >= 6
+#elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 

--- a/src/ztopt_compat.c
+++ b/src/ztopt_compat.c
@@ -8,6 +8,8 @@
 
 #if __GNUC__ < 4
 #error "gcc version >= 4 is required"
+#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 6
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #elif __GNUC_MINOR__ >= 4
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif


### PR DESCRIPTION
It looks like there's been a buildup of gcc errors on Linux (which I suspect that we've missed because most of the devs are on Mac boxes and using clang).