### PR TITLE
Fix Monitor and Recv bug with Max results

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -132,7 +132,7 @@ double compute_remaining_time(double age, uint64_t tried_sent)
 		}
 		if (zconf.max_results) {
 			double done =
-			    (double)zrecv.success_unique / zconf.max_results;
+			    (double)zrecv.filter_success / zconf.max_results;
 			remaining[2] = (1. - done) * (age / done);
 		}
 		if (zsend.max_index) {

--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -37,7 +37,7 @@ void packet_cb(u_char __attribute__((__unused__)) * user,
 	if (!p) {
 		return;
 	}
-	if (zrecv.success_unique >= zconf.max_results) {
+	if (zrecv.filter_success >= zconf.max_results) {
 		// Libpcap can process multiple packets per pcap_dispatch;
 		// we need to throw out results once we've
 		// gotten our --max-results worth.


### PR DESCRIPTION
I believe this resolves #518 

I tested this with the flags provided in #518 before these changes and confirmed the same behavior, after this fix I observed normal behavior. 