### PR TITLE
Fix bug in prefix length check, typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 #        docker build -t zmap_ubuntu -f Dockerfile .
 #
-#   * If you wisht to build a specific commit, use the ZMAP_COMMIT build argument.
+#   * If you wish to build a specific commit, use the ZMAP_COMMIT build argument.
 #
 #        docker build -t zmap_ubuntu -f Dockerfile --build-arg ZMAP_COMMIT=<your commit> .
 #

--- a/lib/constraint.c
+++ b/lib/constraint.c
@@ -107,7 +107,7 @@ static void _convert_to_leaf(node_t *node)
 static void _set_recurse(node_t *node, uint32_t prefix, int len, value_t value)
 {
 	assert(node);
-	assert(0 <= len && len <= 32);
+	assert(0 <= len && len <= 256);
 
 	if (len == 0) {
 		// We're at the end of the prefix; make this a leaf and set the


### PR DESCRIPTION
I believe this resolves #528 and I confirmed that this works in Docker.