### PR TITLE
Fixed issue #572

### DIFF
--- a/src/output_modules/module_redis_csv.c
+++ b/src/output_modules/module_redis_csv.c
@@ -182,7 +182,7 @@ void make_csv_string(fieldset_t *fs, char *out, size_t len)
 				log_fatal("redis-csv",
 					  "out of memory---will overflow");
 			}
-			hex_encode_str(out, (unsigned char *)f->value.ptr,
+			hex_encode_str(dataloc, (unsigned char *)f->value.ptr,
 				       f->len);
 		} else if (f->type == FS_NULL) {
 			// do nothing


### PR DESCRIPTION
Fixed a typo in redis-csv output module that will cause binary field
overwriting prior fields in the output.