### PR TITLE
Fix incorrect default prefix length for targets

### DIFF
--- a/lib/blacklist.c
+++ b/lib/blacklist.c
@@ -104,7 +104,7 @@ void whitelist_prefix(char *ip, int prefix_len)
 
 static int init_from_string(char *ip, int value)
 {
-	int prefix_len = 256;
+	int prefix_len = 32;
 	char *slash = strchr(ip, '/');
 	if (slash) { // split apart network and prefix length
 		*slash = '\0';
@@ -113,7 +113,7 @@ static int init_from_string(char *ip, int value)
 		errno = 0;
 		prefix_len = strtol(len, &end, 10);
 		if (end == len || errno != 0 || prefix_len < 0 ||
-		    prefix_len > 256) {
+		    prefix_len > 32) {
 			log_fatal("constraint",
 				  "'%s' is not a valid prefix length", len);
 			return -1;


### PR DESCRIPTION
The default prefix length if none is given should be 32 and not 256, as
256 is not a valid prefix length.

Resolves #591.

This bug was introduced by 0e94a7cd7c3f4fd363af9c39cb882a218439491b
in PR #526.