### PR TITLE
Fix build against json-c 0.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if(JSON_FOUND)
 else()
     message(FATAL_ERROR "Did not find libjson")
 endif()
+string(REPLACE ";" " " JSON_CFLAGS "${JSON_CFLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${JSON_CFLAGS}")
 
 if(WITH_REDIS)


### PR DESCRIPTION
The new pkgconfig file contains two include directories:

```
Cflags: -I${includedir} -I${includedir}/json-c
```

Apparently pkg_check_modules returns them as a semicolon-separated string ("CMake list"), which causes the build to fail when appended directly to `CMAKE_C_FLAGS`.

There's probably a proper way to handle this, please let me know if you know it.