### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/test/test_zblocklist.py
+++ b/test/test_zblocklist.py
@@ -131,7 +131,7 @@ class ZBlocklistTest(unittest.TestCase):
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print "USAGE: %s zblocklist" % sys.argv[0]
+        print("USAGE: %s zblocklist" % sys.argv[0])
         sys.exit(1)
     executable_path = sys.argv[1]
     assert(os.path.exists(executable_path))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Python 2 died on 1/1/2020.