### PR TITLE
Travis CI: dist: xenial because Trusty is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ addons:
       - python-dev
       - python-pip
       - libhiredis-dev
+jobs:
+  include:
+    - dist: trusty
+    - dist: xenial
+    - dist: bionic
+    - dist: focal
 before_install:
   - pip install --user sh
   - export PATH=/opt/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 os: linux
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:
@@ -18,12 +18,6 @@ addons:
       - python-dev
       - python-pip
       - libhiredis-dev
-jobs:
-  include:
-    - dist: trusty
-    - dist: xenial
-    - dist: bionic
-    - dist: focal
 before_install:
   - pip install --user sh
   - export PATH=/opt/bin:$PATH


### PR DESCRIPTION
* `dist: bionic` fails on `Package 'libstdc++-4.9-dev' has no installation candidate`
* `dist: focal` fails because you cannot install legacy Python on it.