### PR TITLE
Implement SYN SCAN with MP_CAPABLE option for multipath TCP support discovery

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,8 +29,9 @@ set(PROBE_MODULE_SOURCES
     probe_modules/module_icmp_echo.c
     probe_modules/module_icmp_echo_time.c
     probe_modules/module_tcp_synscan.c
+    probe_modules/module_tcp_mpsynscan.c
     probe_modules/module_tcp_synackscan.c
-	#probe_modules/module_tcp_cisco_backdoor.c
+    #probe_modules/module_tcp_cisco_backdoor.c
     probe_modules/module_udp.c
     probe_modules/packet.c
     probe_modules/probe_modules.c

--- a/src/probe_modules/module_tcp_mpsynscan.c
+++ b/src/probe_modules/module_tcp_mpsynscan.c
@@ -19,17 +19,41 @@
 #include "../fieldset.h"
 #include "probe_modules.h"
 #include "packet.h"
+#include "module_tcp_synscan.h"
 
-probe_module_t module_tcp_synscan;
 static uint32_t num_ports;
 
-static int synscan_global_initialize(struct state_conf *state)
+#define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((x) >> 32))
+#define ntohll(x) ((((uint64_t)ntohl(x)) << 32) + ntohl((x) >> 32))
+// todo::
+// #define HTONLL(x) ((1==htonl(1)) ? (x) : (((uint64_t)htonl((x) & 0xFFFFFFFFUL)) << 32) | htonl((uint32_t)((x) >> 32)))
+// #define NTOHLL(x) ((1==ntohl(1)) ? (x) : (((uint64_t)ntohl((x) & 0xFFFFFFFFUL)) << 32) | ntohl((uint32_t)((x) >> 32)))
+// // ^^ https://stackoverflow.com/questions/16375340/c-htonll-and-back
+
+#define MP_CAPABLE 30
+//#define MP_KEY 0xdeadcafe
+#define MP_KEY htonll(4242424242)
+#define MPTCP_RESET 0
+#define MPTCP_MIRROR 1
+#define MPTCP_EMPTY 2
+#define MPTCP_SUPPORTED 3
+
+struct __attribute__((__packed__)) tcp_options {
+	uint8_t kind;
+	uint8_t size;
+	uint8_t subtype_version;
+	uint8_t flags;
+	uint64_t key;
+};
+
+
+static int mpsynscan_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
 	return EXIT_SUCCESS;
 }
 
-static int synscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
+static int mpsynscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 				  port_h_t dst_port,
 				  __attribute__((unused)) void **arg_ptr)
 {
@@ -37,14 +61,23 @@ static int synscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	struct ether_header *eth_header = (struct ether_header *)buf;
 	make_eth_header(eth_header, src, gw);
 	struct ip *ip_header = (struct ip *)(&eth_header[1]);
-	uint16_t len = htons(sizeof(struct ip) + sizeof(struct tcphdr));
+	uint16_t len = htons(sizeof(struct ip) + sizeof(struct tcphdr) + sizeof(struct tcp_options));
 	make_ip_header(ip_header, IPPROTO_TCP, len);
 	struct tcphdr *tcp_header = (struct tcphdr *)(&ip_header[1]);
 	make_tcp_header(tcp_header, dst_port, TH_SYN);
+	// https://stackoverflow.com/questions/42750552/read-tcp-options-fields
+	// fill in options
+	struct tcp_options *opts = (struct tcp_options*)(&tcp_header[1]);
+	opts->kind = MP_CAPABLE;
+	opts->size = sizeof(struct tcp_options);
+	opts->subtype_version = 0;
+	opts->flags =  1<<7 | 1;
+	opts->key = MP_KEY;
+
 	return EXIT_SUCCESS;
 }
 
-static int synscan_make_packet(void *buf, UNUSED size_t *buf_len,
+static int mpsynscan_make_packet(void *buf, UNUSED size_t *buf_len,
 			       ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
 			       uint32_t *validation, int probe_num,
 			       UNUSED void *arg)
@@ -63,7 +96,7 @@ static int synscan_make_packet(void *buf, UNUSED size_t *buf_len,
 	tcp_header->th_seq = tcp_seq;
 	tcp_header->th_sum = 0;
 	tcp_header->th_sum =
-	    tcp_checksum(sizeof(struct tcphdr), ip_header->ip_src.s_addr,
+	    tcp_checksum(sizeof(struct tcphdr) + sizeof(struct tcp_options), ip_header->ip_src.s_addr,
 			 ip_header->ip_dst.s_addr, tcp_header);
 
 	ip_header->ip_sum = 0;
@@ -72,22 +105,7 @@ static int synscan_make_packet(void *buf, UNUSED size_t *buf_len,
 	return EXIT_SUCCESS;
 }
 
-// not static because used by synack scan
-void synscan_print_packet(FILE *fp, void *packet)
-{
-	struct ether_header *ethh = (struct ether_header *)packet;
-	struct ip *iph = (struct ip *)&ethh[1];
-	struct tcphdr *tcph = (struct tcphdr *)&iph[1];
-	fprintf(fp,
-		"tcp { source: %u | dest: %u | seq: %u | checksum: %#04X }\n",
-		ntohs(tcph->th_sport), ntohs(tcph->th_dport),
-		ntohl(tcph->th_seq), ntohs(tcph->th_sum));
-	fprintf_ip_header(fp, iph);
-	fprintf_eth_header(fp, ethh);
-	fprintf(fp, "------------------------------------------------------\n");
-}
-
-static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
+static int mpsynscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 				   __attribute__((unused)) uint32_t *src_ip,
 				   uint32_t *validation)
 {
@@ -128,7 +146,37 @@ static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 	return 1;
 }
 
-static void synscan_process_packet(const u_char *packet,
+// similar to tcp_parse_options from Linux kernel `
+// https://elixir.bootlin.com/linux/v5.4.25/source/net/ipv4/tcp_input.c#L3839
+static inline struct tcp_options *get_mptcp(struct tcphdr *tcp) {
+
+		int length = (tcp->doff * 4) - sizeof(struct tcphdr);
+		const unsigned char *ptr = (const unsigned char *)&tcp[1];
+
+		while (length > 0) {
+			int opcode = *ptr++;
+			int opsize;
+			switch(opcode) {
+				case TCPOPT_EOL:
+					return NULL;
+				case TCPOPT_NOP:
+					length--;
+					continue;
+				case MP_CAPABLE:
+					return (struct tcp_options*)(ptr - 1);
+				default:
+					if (length< 2) break;
+					opsize = *ptr++;
+					if (opsize < 2) break; // linux does so..
+					if (opsize > length) break;
+					ptr += opsize -2;
+					length -= opsize;
+			}
+		}
+		return NULL;
+}
+
+static void mpsynscan_process_packet(const u_char *packet,
 				   __attribute__((unused)) uint32_t len,
 				   fieldset_t *fs,
 				   __attribute__((unused)) uint32_t *validation,
@@ -145,9 +193,29 @@ static void synscan_process_packet(const u_char *packet,
 	fs_add_uint64(fs, "window", (uint64_t)ntohs(tcp->th_win));
 
 	if (tcp->th_flags & TH_RST) { // RST packet
+		fs_add_uint64(fs, "mptcp", MPTCP_RESET);
 		fs_add_string(fs, "classification", (char *)"rst", 0);
 		fs_add_bool(fs, "success", 0);
 	} else { // SYNACK packet
+
+		struct tcp_options *opts = get_mptcp(tcp);
+		if (opts != NULL)
+		{
+			if (MP_KEY == opts->key)
+			{
+				fs_add_uint64(fs, "mptcp", MPTCP_MIRROR);
+			}
+			else
+			{
+				// can log ntohll(opts->key)
+				// if you want to collect server responce keys
+				fs_add_uint64(fs, "mptcp", MPTCP_SUPPORTED);
+			}
+
+		} else {
+			fs_add_uint64(fs, "mptcp", MPTCP_EMPTY);
+		}
+
 		fs_add_string(fs, "classification", (char *)"synack", 0);
 		fs_add_bool(fs, "success", 1);
 	}
@@ -159,6 +227,7 @@ static fielddef_t fields[] = {
     {.name = "seqnum", .type = "int", .desc = "TCP sequence number"},
     {.name = "acknum", .type = "int", .desc = "TCP acknowledgement number"},
     {.name = "window", .type = "int", .desc = "TCP window"},
+    {.name = "mptcp", .type = "int", .desc = "MPTCP key"},
     {.name = "classification",
      .type = "string",
      .desc = "packet classification"},
@@ -166,23 +235,24 @@ static fielddef_t fields[] = {
      .type = "bool",
      .desc = "is response considered success"}};
 
-probe_module_t module_tcp_synscan = {
-    .name = "tcp_synscan",
-    .packet_length = 54,
+probe_module_t module_tcp_mpsynscan = {
+    .name = "tcp_mpsynscan",
+    .packet_length = sizeof(struct ether_header) + sizeof(struct ip) + sizeof(struct tcphdr) + sizeof(struct tcp_options),
     .pcap_filter = "tcp && tcp[13] & 4 != 0 || tcp[13] == 18",
     .pcap_snaplen = 96,
     .port_args = 1,
-    .global_initialize = &synscan_global_initialize,
-    .thread_initialize = &synscan_init_perthread,
-    .make_packet = &synscan_make_packet,
+    .global_initialize = &mpsynscan_global_initialize,
+    .thread_initialize = &mpsynscan_init_perthread,
+    .make_packet = &mpsynscan_make_packet,
     .print_packet = &synscan_print_packet,
-    .process_packet = &synscan_process_packet,
-    .validate_packet = &synscan_validate_packet,
+    .process_packet = &mpsynscan_process_packet,
+    .validate_packet = &mpsynscan_validate_packet,
     .close = NULL,
-    .helptext = "Probe module that sends a TCP SYN packet to a specific "
+    .helptext = "Probe module that sends a TCP SYN packet with MP_CAPABLE "
+	         "MPTCP (http://multipath-tcp.org/)  extension to a specific "
 		"port. Possible classifications are: synack and rst. A "
 		"SYN-ACK packet is considered a success and a reset packet "
 		"is considered a failed response.",
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
-    .numfields = 7};
+    .numfields = sizeof(fields) / sizeof(fields[0])};

--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -109,7 +109,7 @@ void make_tcp_header(struct tcphdr *tcp_header, port_h_t dest_port,
 	tcp_header->th_seq = random();
 	tcp_header->th_ack = 0;
 	tcp_header->th_x2 = 0;
-	tcp_header->th_off = 5; // data offset
+	tcp_header->th_off = 8; // data offset 5(tcp_header size) + 3 (12 byte mptcp option)
 	tcp_header->th_flags = 0;
 	tcp_header->th_flags |= th_flags;
 	tcp_header->th_win = htons(65535); // largest possible window

--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -21,6 +21,7 @@
 
 // extern probe_module_t module_tcp_cisco_backdoor;
 extern probe_module_t module_tcp_synscan;
+extern probe_module_t module_tcp_mpsynscan;
 extern probe_module_t module_tcp_synackscan;
 extern probe_module_t module_icmp_echo;
 extern probe_module_t module_icmp_echo_time;
@@ -32,7 +33,7 @@ extern probe_module_t module_bacnet;
 // ADD YOUR MODULE HERE
 
 probe_module_t *probe_modules[] = {
-    &module_tcp_synscan, &module_tcp_synackscan, &module_icmp_echo,
+    &module_tcp_synscan, &module_tcp_mpsynscan, &module_tcp_synackscan, &module_icmp_echo,
     &module_icmp_echo_time, &module_udp, &module_ntp, &module_upnp, &module_dns,
     //&module_tcp_cisco_backdoor,
     &module_bacnet


### PR DESCRIPTION
[Multipath TCP](http://multipath-tcp.org/) allows changing endpoint IP addresses without breaking existing TCP connections and is becoming more widely deployed. 
TCP SYN scan is a common way to measure support of MPTCP in the wild, both by end hosts and by middleboxes. [Here](http://blog.multipath-tcp.org/blog/html/2018/12/19/which_servers_use_multipath_tcp.html) is a blog post discussing previous such measurement studies. 

This PR implements a probe into zmap that allows to detect multipath-tcp capable end-hosts and interfering middleboxes.
The probe is very similar to tcp_synscan. The main difference is the additional MPTCP TCP option in sent SYN packets and parsing of the reply TCP option in SYNACK packets.


The PR has some rough edges but before polishing these, wanted to see whether it belongs in upstream zmap.

TODOs before merging

 - [ ] module naming
- [ ] Set `th_off` in `make_tcp_header` based on probe needs
- [ ] Standardize or remove `htonll/ntohll` macros
- [ ] ? Avoid copying logic between `synscan`, `synackscan` and `mpscan`