### PR TITLE
Ensure all probe modules set *buf_len

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -25,6 +25,7 @@
 #include "includes.h"
 #include "xalloc.h"
 
+#include <errno.h>
 #include <unistd.h>
 #include <sched.h>
 #include <pthread.h>
@@ -129,7 +130,6 @@ void fprintw(FILE *f, const char *s, size_t w)
 
 uint32_t parse_max_hosts(char *max_targets)
 {
-	int errno = 0;
 	char *end;
 	double v = strtod(max_targets, &end);
 	if (end == max_targets || errno != 0) {

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -21,6 +21,8 @@
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 
+#define ZMAP_BACNET_PACKET_LEN (sizeof(struct ether_header) + sizeof(struct ip) + sizeof(struct udphdr) + 0x11)
+
 probe_module_t module_bacnet;
 
 static int num_ports;
@@ -71,7 +73,7 @@ int bacnet_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	return EXIT_SUCCESS;
 }
 
-int bacnet_make_packet(void *buf, UNUSED size_t *buf_len,
+int bacnet_make_packet(void *buf, size_t *buf_len,
                ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
 			   uint32_t *validation, int probe_num,
 		       UNUSED void *arg)
@@ -92,6 +94,7 @@ int bacnet_make_packet(void *buf, UNUSED size_t *buf_len,
 	bnp->apdu.invoke_id = get_invoke_id(validation);
 
 	ip_header->ip_sum = zmap_ip_checksum((unsigned short *)ip_header);
+	*buf_len = ZMAP_BACNET_PACKET_LEN;
 
 	return EXIT_SUCCESS;
 }
@@ -211,8 +214,7 @@ static fielddef_t fields[] = {
 
 probe_module_t module_bacnet = {
     .name = "bacnet",
-    .packet_length = sizeof(struct ether_header) + sizeof(struct ip) +
-		     sizeof(struct udphdr) + 0x11,
+    .max_packet_length = ZMAP_BACNET_PACKET_LEN,
     .pcap_filter = "udp || icmp",
     .pcap_snaplen = 1500,
     .port_args = 1,

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -6,36 +6,36 @@
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-/* Module for scanning for open UDP DNS resolvers.
- *
- * This module optionally takes in an argument of the form "TYPE,QUESTION"
- * (e.g. "A,google.com").
- *
- * Given no arguments it will default to asking for an A record for
- * www.google.com.
- *
- * This module does minimal answer verification. It only verifies that the
- * response roughly looks like a DNS response. It will not, for example,
- * require the QR bit be set to 1. All such analysis should happen offline.
- * Specifically, to be included in the output it requires:
- * - That the response packet is >= the query packet.
- * - That the ports match and the packet is complete.
- * To be marked as success it also requires:
- * - That the response bytes that should be the ID field matches the send bytes.
- * - That the response bytes that should be question match send bytes.
- * To be marked as app_success it also requires:
- * - That the QR bit be 1 and rcode == 0.
- *
- * Usage: zmap -p 53 --probe-module=dns --probe-args="ANY,www.example.com"
- *			-O json --output-fields=* 8.8.8.8
- *
- * We also support multiple questions, of the form:
- *"A,example.com;AAAA,www.example.com" This requires --probes=X, where X matches
- *the number of questions in --probe-args, and --output-filter="" to remove the
- *implicit "filter_duplicates" configuration flag.
- *
- * Based on a deprecated udp_dns module.
- */
+// Module for scanning for open UDP DNS resolvers.
+//
+// This module optionally takes in an argument of the form "TYPE,QUESTION"
+// (e.g. "A,google.com").
+//
+// Given no arguments it will default to asking for an A record for
+// www.google.com.
+//
+// This module does minimal answer verification. It only verifies that the
+// response roughly looks like a DNS response. It will not, for example,
+// require the QR bit be set to 1. All such analysis should happen offline.
+// Specifically, to be included in the output it requires:
+//   - That the response packet is >= the query packet.
+//   - That the ports match and the packet is complete.
+// To be marked as success it also requires:
+//   - That the response bytes that should be the ID field matches the send bytes.
+//   - That the response bytes that should be question match send bytes.
+// To be marked as app_success it also requires:
+//   - That the QR bit be 1 and rcode == 0.
+//
+// Usage:
+//     zmap -p 53 --probe-module=dns --probe-args="ANY,www.example.com"
+//         -O json --output-fields=* 8.8.8.8
+//
+// We also support multiple questions, of the form:
+// "A,example.com;AAAA,www.example.com" This requires --probes=X, where X
+// matches the number of questions in --probe-args, and either
+// --output-filter="" or --output-module=csv to remove the implicit
+// "filter_duplicates" configuration flag.
+//
 
 #include "module_dns.h"
 #include <stdlib.h>
@@ -54,7 +54,7 @@
 #include "module_udp.h"
 #include "../fieldset.h"
 
-#define DNS_SEND_LEN 512 // This is arbitrary
+#define DNS_PAYLOAD_LEN_LIMIT 512 // This is arbitrary
 #define UDP_HEADER_LEN 8
 #define PCAP_SNAPLEN 1500 // This is even more arbitrary
 #define UNUSED __attribute__((unused))
@@ -154,20 +154,26 @@ static uint16_t domain_to_qname(char **qname_handle, const char *domain)
 	return len;
 }
 
-static int build_global_dns_packets(char *domains[], int num_domains)
+static int build_global_dns_packets(char *domains[], int num_domains, size_t *max_len)
 {
+	size_t _max_len = 0;
 	for (int i = 0; i < num_domains; i++) {
 
 		qname_lens[i] = domain_to_qname(&qnames[i], domains[i]);
 		if (domains[i] != (char *)default_domain) {
 			free(domains[i]);
 		}
-		dns_packet_lens[i] = sizeof(dns_header) + qname_lens[i] +
+		uint16_t len = sizeof(dns_header) + qname_lens[i] +
 				     sizeof(dns_question_tail);
-		if (dns_packet_lens[i] > DNS_SEND_LEN) {
+		dns_packet_lens[i] = len;
+		if (len > _max_len) {
+			_max_len = len;
+		}
+
+		if (dns_packet_lens[i] > DNS_PAYLOAD_LEN_LIMIT) {
 			log_fatal("dns",
 				  "DNS packet bigger (%d) than our limit (%d)",
-				  dns_packet_lens[i], DNS_SEND_LEN);
+				  dns_packet_lens[i], DNS_PAYLOAD_LEN_LIMIT);
 			return EXIT_FAILURE;
 		}
 
@@ -187,11 +193,10 @@ static int build_global_dns_packets(char *domains[], int num_domains)
 		memcpy(qname_p, qnames[i], qname_lens[i]);
 		// Set the qtype to what we passed from args
 		tail_p->qtype = htons(qtypes[i]);
-		// Set the qclass to The Internet (TM) (R) (I hope you're happy
-		// now Zakir)
-		tail_p->qclass = htons(
-		    0x01); // MAGIC NUMBER. Let's be honest. This is only ever 1
+		// Set the qclass to The Internet
+		tail_p->qclass = htons(0x01);
 	}
+	*max_len = _max_len;
 	return EXIT_SUCCESS;
 }
 
@@ -591,12 +596,11 @@ static int dns_global_initialize(struct state_conf *conf)
 		qtypes[i] = default_qtype;
 	}
 
-	// This is zmap boilerplate. Why do I have to write this?
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
 	udp_set_num_ports(num_ports);
 	setup_qtype_str_map();
 
-	if (conf->probe_args) { // no parameters passed in. Use defaults
+	if (conf->probe_args) {
 		int arg_strlen = strlen(conf->probe_args);
 		char *arg_pos = conf->probe_args;
 
@@ -658,7 +662,13 @@ static int dns_global_initialize(struct state_conf *conf)
 			    "More args than probes passed. Add additional probes.");
 		}
 	}
-	return build_global_dns_packets(domains, num_questions);
+	size_t max_payload_len;
+	int ret = build_global_dns_packets(domains, num_questions, &max_payload_len);
+	module_dns.max_packet_length = max_payload_len
+	     + sizeof(struct ether_header)
+	     + sizeof(struct ip)
+	     + sizeof(struct udphdr);
+	return ret;
 }
 
 static int dns_global_cleanup(UNUSED struct state_conf *zconf,
@@ -719,10 +729,6 @@ int dns_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	make_udp_header(udp_header, zconf.target_port, len);
 
 	char *payload = (char *)(&udp_header[1]);
-	module_dns.packet_length = sizeof(struct ether_header) +
-				   sizeof(struct ip) + sizeof(struct udphdr) +
-				   dns_packet_lens[0];
-	assert(module_dns.packet_length <= MAX_PACKET_SIZE);
 
 	memcpy(payload, dns_packets[0], dns_packet_lens[0]);
 
@@ -1162,7 +1168,7 @@ static fielddef_t fields[] = {
 
 probe_module_t module_dns = {
     .name = "dns",
-    .packet_length = DNS_SEND_LEN + UDP_HEADER_LEN,
+    .max_packet_length = 0, // set in init
     .pcap_filter = "udp || icmp",
     .pcap_snaplen = PCAP_SNAPLEN,
     .port_args = 1,

--- a/src/probe_modules/module_icmp_echo.c
+++ b/src/probe_modules/module_icmp_echo.c
@@ -107,9 +107,9 @@ int icmp_global_initialize(struct state_conf *conf)
 		return EXIT_FAILURE;
 	}
 
-	module_icmp_echo.packet_length = sizeof(struct ether_header) +
+	module_icmp_echo.max_packet_length = sizeof(struct ether_header) +
 							   sizeof(struct ip) + ICMP_MINLEN + icmp_payload_len;
-	assert(module_icmp_echo.packet_length <= 1500);
+	assert(module_icmp_echo.max_packet_length <= 1500);
 	return EXIT_SUCCESS;
 }
 
@@ -150,7 +150,7 @@ static int icmp_echo_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	return EXIT_SUCCESS;
 }
 
-static int icmp_echo_make_packet(void *buf, UNUSED size_t *buf_len,
+static int icmp_echo_make_packet(void *buf, size_t *buf_len,
 				 ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
 				 uint32_t *validation, UNUSED int probe_num,
 				 UNUSED void *arg)
@@ -318,7 +318,7 @@ static fielddef_t fields[] = {
 	{.name = "data", .type = "binary", .desc = "ICMP payload"}};
 
 probe_module_t module_icmp_echo = {.name = "icmp_echoscan",
-				   .packet_length = 48,
+				   .max_packet_length = 48,
 				   .pcap_filter = "icmp and icmp[0]!=8",
 				   .pcap_snaplen = 96,
 				   .port_args = 0,

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -201,14 +201,12 @@ int ntp_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 
 	make_udp_header(udp_header, zconf.target_port, len);
 
-	char *payload = (char *)(&ntp_header[1]);
-
-	module_ntp.packet_length = sizeof(struct ether_header) +
-				   sizeof(struct ip) + sizeof(struct udphdr) +
-				   sizeof(struct ntphdr);
-
-	assert(module_ntp.packet_length <= MAX_PACKET_SIZE);
-	memcpy(payload, ntp_header, module_ntp.packet_length);
+	// TODO(dadrian): Should this have a payload? It was being set incorrectly.
+	size_t header_len = sizeof(struct ether_header)
+	    + sizeof(struct ip)
+	    + sizeof(struct udphdr)
+	    + sizeof(struct ntphdr);
+	module_ntp.max_packet_length = header_len;
 
 	uint32_t seed = aesrand_getword(zconf.aes);
 	aesrand_t *aes = aesrand_init_from_seed(seed);
@@ -277,7 +275,7 @@ static fielddef_t fields[] = {
 };
 
 probe_module_t module_ntp = {.name = "ntp",
-			     .packet_length = 1,
+			     .max_packet_length = 0, // set in init
 			     .pcap_filter = "udp || icmp",
 			     .pcap_snaplen = 1500,
 			     .port_args = 1,

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -21,6 +21,8 @@
 #include "packet.h"
 #include "module_tcp_synscan.h"
 
+#define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 54
+
 probe_module_t module_tcp_synackscan;
 static uint32_t num_ports;
 
@@ -72,6 +74,7 @@ static int synackscan_make_packet(void *buf, UNUSED size_t *buf_len,
 
 	ip_header->ip_sum = 0;
 	ip_header->ip_sum = zmap_ip_checksum((unsigned short *)ip_header);
+	*buf_len = ZMAP_TCP_SYNACKSCAN_PACKET_LEN;
 
 	return EXIT_SUCCESS;
 }
@@ -165,7 +168,7 @@ static fielddef_t fields[] = {
 
 probe_module_t module_tcp_synackscan = {
     .name = "tcp_synackscan",
-    .packet_length = 54,
+    .max_packet_length = ZMAP_TCP_SYNACKSCAN_PACKET_LEN,
     .pcap_filter = "tcp && tcp[13] & 4 != 0 || tcp[13] == 18",
     .pcap_snaplen = 96,
     .port_args = 1,

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -20,6 +20,8 @@
 #include "probe_modules.h"
 #include "packet.h"
 
+#define ZMAP_TCP_SYNSCAN_PACKET_LEN 54
+
 probe_module_t module_tcp_synscan;
 static uint32_t num_ports;
 
@@ -44,7 +46,7 @@ static int synscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	return EXIT_SUCCESS;
 }
 
-static int synscan_make_packet(void *buf, UNUSED size_t *buf_len,
+static int synscan_make_packet(void *buf, size_t *buf_len,
 			       ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
 			       uint32_t *validation, int probe_num,
 			       UNUSED void *arg)
@@ -69,6 +71,7 @@ static int synscan_make_packet(void *buf, UNUSED size_t *buf_len,
 	ip_header->ip_sum = 0;
 	ip_header->ip_sum = zmap_ip_checksum((unsigned short *)ip_header);
 
+	*buf_len = ZMAP_TCP_SYNSCAN_PACKET_LEN;
 	return EXIT_SUCCESS;
 }
 
@@ -168,7 +171,7 @@ static fielddef_t fields[] = {
 
 probe_module_t module_tcp_synscan = {
     .name = "tcp_synscan",
-    .packet_length = 54,
+    .max_packet_length = ZMAP_TCP_SYNSCAN_PACKET_LEN,
     .pcap_filter = "tcp && tcp[13] & 4 != 0 || tcp[13] == 18",
     .pcap_snaplen = 96,
     .port_args = 1,

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -756,7 +756,6 @@ int udp_template_field_lookup(const char *vname, udp_payload_field_t *c)
 	}
 
 	// Find a field that matches the
-	log_error("udp_template", "vname: %.*s", type_name_len, vname);
 	for (unsigned int f = 0; f < fcount; f++) {
 		const udp_payload_field_type_def_t* ftype = &udp_payload_template_fields[f];
 		if (strncmp(vname, ftype->name, type_name_len) == 0 && strlen(ftype->name) == type_name_len) {
@@ -858,7 +857,6 @@ udp_payload_template_t *udp_template_load(uint8_t *buf, uint32_t buf_len,
 		lbrack = NULL;
 		p++;
 	}
-	log_error("udp", "%s", "template loaded");
 
 	// Store the trailing bytes as a final data field
 	if (s < p) {

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -59,10 +59,12 @@ typedef struct udp_payload_output {
 
 void udp_print_packet(FILE *fp, void *packet);
 
-int udp_make_packet(void *buf, size_t *buf_len,
-            ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
-			uint32_t *validation, int probe_num,
-		    void *arg);
+int udp_make_packet(void *buf, size_t *buf_len, ipaddr_n_t src_ip,
+		    ipaddr_n_t dst_ip, uint8_t ttl, uint32_t *validation,
+		    int probe_num, void *arg);
+int udp_make_templated_packet(void *buf, size_t *buf_len, ipaddr_n_t src_ip,
+			      ipaddr_n_t dst_ip, uint8_t ttl,
+			      uint32_t *validation, int probe_num, void *arg);
 
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			__attribute__((unused)) uint32_t *src_ip,
@@ -92,4 +94,5 @@ int udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 
 int udp_template_field_lookup(const char *vname, udp_payload_field_t *c);
 
-udp_payload_template_t *udp_template_load(char *buf, uint32_t buf_len, uint32_t *max_pkt_len);
+udp_payload_template_t *udp_template_load(uint8_t *buf, uint32_t buf_len,
+					  uint32_t *max_pkt_len);

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -37,6 +37,7 @@ typedef enum udp_payload_field_type {
 typedef struct udp_payload_field_type_def {
 	const char *name;
 	const char *desc;
+	size_t max_length;
 	udp_payload_field_type_t ftype;
 } udp_payload_field_type_def_t;
 
@@ -89,6 +90,6 @@ int udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 		       struct ip *ip_hdr, struct udphdr *udp_hdr,
 		       aesrand_t *aes);
 
-int udp_template_field_lookup(char *vname, udp_payload_field_t *c);
+int udp_template_field_lookup(const char *vname, udp_payload_field_t *c);
 
-udp_payload_template_t *udp_template_load(char *buf, unsigned int len);
+udp_payload_template_t *udp_template_load(char *buf, uint32_t buf_len, uint32_t *max_pkt_len);

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -264,7 +264,7 @@ static fielddef_t fields[] = {
 
 probe_module_t module_upnp = {
     .name = "upnp",
-    .packet_length = 139,
+    .max_packet_length = 139,
     .pcap_filter = "udp || icmp",
     .pcap_snaplen = 2048,
     .port_args = 1,

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -36,6 +36,20 @@ typedef int (*probe_thread_init_cb)(void *packetbuf, macaddr_t *src_mac,
 				    macaddr_t *gw_mac, port_n_t src_port,
 				    void **arg_ptr);
 
+// The make_packet callback is passed a buffer pointing at an ethernet header.
+// The buffer is MAX_PACKET_SIZE bytes. The callback must update the value
+// pointed at by buf_len with the actual length of the packet. The contents of
+// the buffer will match the previous packet sent. Every invocation of
+// make_packet contains a unique (src_ip, probe_num) tuple.
+//
+// The probe module is responsible for populating the IP header. The src_ip,
+// dst_ip, and ttl are provided by the framework and must be set on the IP
+// header.
+//
+// The uin32_t validation parameter is a pointer to four 4-byte words of
+// validation data.  The data is deterministic based on the the validation
+// state, and is constant across a src_ip. To get the src_port, use the
+// get_src_port function which takes probe_num and validation as parameters.
 typedef int (*probe_make_packet_cb)(void *packetbuf, size_t *buf_len,
 				    ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
 				    uint32_t *validation, int probe_num,
@@ -52,7 +66,12 @@ typedef void (*probe_classify_packet_cb)(const u_char *packetbuf, uint32_t len,
 
 typedef struct probe_module {
 	const char *name;
-	size_t packet_length;
+
+	// TODO(dadrian): Completely get rid of this. We can do bandwidth rate
+	// limiting by actually counting how much data is sent over the wire. We
+	// know the lengths of packets from the make_packet API.
+	size_t max_packet_length;
+
 	const char *pcap_filter;
 	size_t pcap_snaplen;
 


### PR DESCRIPTION
Probe modules with dynamic output already needed to set `*buf_len`
during calls to `make_packet`. Not all probe modules did this. Some
opted to update the value of `probe_module.packet_length`. This is not
safe in a multithreaded invocation.

This commit forces all probe modules to update `*buf_len`, and replaces
the packet_length parameter with a max_packet_length, which is used for
bandwidth rate calculation as an upper bound. It is unclear if the rate
calculation works currently, but at least it's getting consistent input
now.