### PR TITLE
Set MSS to default Linux MSS in synscan modules

### DIFF
--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -21,7 +21,8 @@
 #include "packet.h"
 #include "module_tcp_synscan.h"
 
-#define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 54
+#define ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN 24
+#define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 58
 
 probe_module_t module_tcp_synackscan;
 static uint32_t num_ports;
@@ -40,10 +41,11 @@ static int synackscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	struct ether_header *eth_header = (struct ether_header *)buf;
 	make_eth_header(eth_header, src, gw);
 	struct ip *ip_header = (struct ip *)(&eth_header[1]);
-	uint16_t len = htons(sizeof(struct ip) + sizeof(struct tcphdr));
+	uint16_t len = htons(sizeof(struct ip) + ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN);
 	make_ip_header(ip_header, IPPROTO_TCP, len);
 	struct tcphdr *tcp_header = (struct tcphdr *)(&ip_header[1]);
 	make_tcp_header(tcp_header, dst_port, TH_SYN | TH_ACK);
+	set_tcp_options(tcp_header);
 	return EXIT_SUCCESS;
 }
 
@@ -69,7 +71,7 @@ static int synackscan_make_packet(void *buf, UNUSED size_t *buf_len,
 	tcp_header->th_ack = tcp_ack;
 	tcp_header->th_sum = 0;
 	tcp_header->th_sum =
-	    tcp_checksum(sizeof(struct tcphdr), ip_header->ip_src.s_addr,
+	    tcp_checksum(ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN, ip_header->ip_src.s_addr,
 			 ip_header->ip_dst.s_addr, tcp_header);
 
 	ip_header->ip_sum = 0;

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -45,7 +45,7 @@ static int synackscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	make_ip_header(ip_header, IPPROTO_TCP, len);
 	struct tcphdr *tcp_header = (struct tcphdr *)(&ip_header[1]);
 	make_tcp_header(tcp_header, dst_port, TH_SYN | TH_ACK);
-	set_tcp_options(tcp_header);
+	set_mss_option(tcp_header);
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -44,7 +44,7 @@ static int synscan_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	make_ip_header(ip_header, IPPROTO_TCP, len);
 	struct tcphdr *tcp_header = (struct tcphdr *)(&ip_header[1]);
 	make_tcp_header(tcp_header, dst_port, TH_SYN);
-	set_tcp_options(tcp_header);
+	set_mss_option(tcp_header);
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -118,21 +118,22 @@ void make_tcp_header(struct tcphdr *tcp_header, port_h_t dest_port,
 	tcp_header->th_dport = htons(dest_port);
 }
 
-size_t set_tcp_options(struct tcphdr *tcp_header) {
+size_t set_mss_option(struct tcphdr *tcp_header) {
 	// This only sets MSS, which is a single-word option.
-	tcp_header->th_off = 6;
-	uint8_t *opts = (uint8_t*) &tcp_header[1];
+	size_t header_size = tcp_header->th_off * 4;
+	uint8_t *base = (uint8_t *) tcp_header;
+	uint8_t *last_opt = (uint8_t*) base + header_size;
 
 	// TCP Option "header"
-	opts[0] = 2; // MSS
-	opts[1] = 4; // MSS is 4 bytes long
+	last_opt[0] = 2; // MSS
+	last_opt[1] = 4; // MSS is 4 bytes long
 
-	// Default Linux MSS is 1450, which 0x05b4
-	opts[2] = 0x05;
-	opts[3] = 0xb4;
+	// Default Linux MSS is 1460, which 0x05b4
+	last_opt[2] = 0x05;
+	last_opt[3] = 0xb4;
 
-	// The header with MSS option is six 4-byte words
-	return 6*4;
+	tcp_header->th_off += 1;
+	return tcp_header->th_off*4;
 }
 
 void make_udp_header(struct udphdr *udp_header, port_h_t dest_port,

--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -118,6 +118,23 @@ void make_tcp_header(struct tcphdr *tcp_header, port_h_t dest_port,
 	tcp_header->th_dport = htons(dest_port);
 }
 
+size_t set_tcp_options(struct tcphdr *tcp_header) {
+	// This only sets MSS, which is a single-word option.
+	tcp_header->th_off = 6;
+	uint8_t *opts = (uint8_t*) &tcp_header[1];
+
+	// TCP Option "header"
+	opts[0] = 2; // MSS
+	opts[1] = 4; // MSS is 4 bytes long
+
+	// Default Linux MSS is 1450, which 0x05b4
+	opts[2] = 0x05;
+	opts[3] = 0xb4;
+
+	// The header with MSS option is six 4-byte words
+	return 6*4;
+}
+
 void make_udp_header(struct udphdr *udp_header, port_h_t dest_port,
 		     uint16_t len)
 {

--- a/src/probe_modules/packet.h
+++ b/src/probe_modules/packet.h
@@ -28,7 +28,7 @@ void make_eth_header(struct ether_header *ethh, macaddr_t *src, macaddr_t *dst);
 
 void make_ip_header(struct ip *iph, uint8_t, uint16_t);
 void make_tcp_header(struct tcphdr *, port_h_t, uint16_t);
-size_t set_tcp_options(struct tcphdr *tcp_header);
+size_t set_mss_option(struct tcphdr *tcp_header);
 void make_icmp_header(struct icmp *);
 void make_udp_header(struct udphdr *udp_header, port_h_t dest_port,
 		     uint16_t len);

--- a/src/probe_modules/packet.h
+++ b/src/probe_modules/packet.h
@@ -28,6 +28,7 @@ void make_eth_header(struct ether_header *ethh, macaddr_t *src, macaddr_t *dst);
 
 void make_ip_header(struct ip *iph, uint8_t, uint16_t);
 void make_tcp_header(struct tcphdr *, port_h_t, uint16_t);
+size_t set_tcp_options(struct tcphdr *tcp_header);
 void make_icmp_header(struct icmp *);
 void make_udp_header(struct udphdr *udp_header, port_h_t dest_port,
 		     uint16_t len);


### PR DESCRIPTION
For both synscan and synackscan, set MSS to 1450. This is the default
Linux MSS, and the option is required to be set for certain hosts to
respond.

Fixes #601