### PR TITLE
Fix handling of hex UDP args.

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -188,7 +188,7 @@ int udp_global_initialize(struct state_conf *conf)
 
 		udp_template = udp_template_load(in, in_len, &udp_template_max_len);
 		module_udp.make_packet = udp_make_templated_packet;
-	} else if (strcmp(args, "hex") == 0) {
+	} else if (strncmp(args, "hex", arg_name_len) == 0) {
 		udp_fixed_payload_len = strlen(c) / 2;
 		udp_fixed_payload = xmalloc(udp_fixed_payload_len);
 


### PR DESCRIPTION
In the current code it is not possible to pass `--probe-args=hex:..` to the `udp` probe module. The following error message is displayed:
```
udp: unknown UDP probe specification (expected file:/path or text:STRING or hex:01020304 or template:/path or template-fields)
```