### PR TITLE
udp_do_validate_packet - return after invalid packet

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -452,6 +452,7 @@ int udp_do_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		if (icmp_helper_validate(ip_hdr, len, sizeof(struct udphdr),
 					 &ip_inner,
 					 &ip_inner_len) == PACKET_INVALID) {
+			return PACKET_INVALID;
 		}
 		struct udphdr *udp = get_udp_header(ip_inner, ip_inner_len);
 		// we can always check the destination port because this is the


### PR DESCRIPTION
I was getting a segmentation fault due to this missing return.