### PR TITLE
Fix template substitution for UDP module

### DIFF
--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -639,7 +639,7 @@ int udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 				break;
 			}
 			u16 = (uint16_t *)p;
-			*u16 = udp_hdr->uh_sport;
+			*u16 = udp_hdr->uh_dport;
 			p += 2;
 			break;
 
@@ -658,7 +658,7 @@ int udp_template_build(udp_payload_template_t *t, char *out, unsigned int len,
 				full = 1;
 				break;
 			}
-			y = snprintf(tmp, 6, "%d", ntohs(udp_hdr->uh_sport));
+			y = snprintf(tmp, 6, "%d", ntohs(udp_hdr->uh_dport));
 			memcpy(p, tmp, y);
 			p += y;
 			break;


### PR DESCRIPTION
Fixes the destination port substitution for UDP packet templates.

## context
```
root@sandbox:~# zmap --version
zmap 2.1.0

root@sandbox:~# cat udp_template
dest_${DPORT}_source_${SPORT}

root@sandbox:~# tcpdump -A 'udp port 8888' &
[1] 20544
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
```

## Before fix
```
root@sandbox:~# zmap -M udp -p 8888 127.0.0.1 -S 127.0.0.1  --probe-args=template:./udp_template  -f saddr,data -o -
Jul 26 17:59:42.467 [WARN] zmap: too few targets relative to senders, dropping to one sender
Jul 26 17:59:42.679 [INFO] zmap: output module: csv
saddr,data
18:06:08.422581 IP localhost.46599 > localhost.8888: UDP, length 23
E..2.1................".....dest_46599_source_46599
.......
 ^C
```

## After fix
```
root@sandbox:~# zmap -M udp -p 8888 127.0.0.1 -S 127.0.0.1  --probe-args=template:./udp_template  -f saddr,data -o -
Jul 26 17:59:42.467 [WARN] zmap: too few targets relative to senders, dropping to one sender
Jul 26 17:59:42.679 [INFO] zmap: output module: csv
saddr,data
18:08:33.006125 IP localhost.40727 > localhost.8888: UDP, length 22
E..2.1................".....dest_8888_source_40727
.......
^C
```