### PR TITLE
Use CLOCK_MONOTONIC for rate limiting (fix #706)

### DIFF
--- a/lib/logger.c
+++ b/lib/logger.c
@@ -267,6 +267,19 @@ double now(void)
 	return (double)now.tv_sec + (double)now.tv_usec / 1000000.;
 }
 
+double steady_now(void)
+{
+#if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK)
+	struct timespec tp;
+	clock_gettime(CLOCK_MONOTONIC, &tp);
+	return (double)tp.tv_sec + (double)tp.tv_nsec / 1000000000.;
+#else
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	return (double)now.tv_sec + (double)now.tv_usec / 1000000.;
+#endif
+}
+
 size_t dstrftime(char *buf, size_t maxsize, const char *format, double tm)
 {
 	struct timeval tv;

--- a/lib/logger.h
+++ b/lib/logger.h
@@ -60,7 +60,18 @@ void check_and_log_file_error(FILE *file, const char *name);
 
 size_t dstrftime(char *, size_t, const char *, double);
 
+// The number of seconds and microseconds since the Epoch.
 double now();
+
+// The number of seconds and nanoseconds since an unspecified point in time.
+// On supported hosts, this value is guaranteed to never decrease.
+//
+// According to the POSIX specification the `clock_gettime` function is part
+// of the Timers option and may not be available on all implementations.
+//
+// On hosts where a monotonic clock is not available, this falls back
+// to `gettimeofday` which was ZMap's original implementation.
+double steady_now();
 
 #ifdef __cplusplus
 }

--- a/src/send.c
+++ b/src/send.c
@@ -73,15 +73,6 @@ void sig_handler_decrease_speed(UNUSED int signal)
 		 zconf.rate);
 }
 
-// A monotonic clock whose value is guaranteed to never decrease.
-// This is useful for rate limiting.
-double steady_now(void)
-{
-	struct timespec tp;
-	clock_gettime(CLOCK_MONOTONIC, &tp);
-	return (double)tp.tv_sec + (double)tp.tv_nsec / 1000000000.;
-}
-
 // global sender initialize (not thread specific)
 iterator_t *send_init(void)
 {

--- a/src/send.c
+++ b/src/send.c
@@ -73,6 +73,15 @@ void sig_handler_decrease_speed(UNUSED int signal)
 		 zconf.rate);
 }
 
+// A monotonic clock whose value is guaranteed to never decrease.
+// This is useful for rate limiting.
+double steady_now(void)
+{
+	struct timespec tp;
+	clock_gettime(CLOCK_MONOTONIC, &tp);
+	return (double)tp.tv_sec + (double)tp.tv_nsec / 1000000000.;
+}
+
 // global sender initialize (not thread specific)
 iterator_t *send_init(void)
 {
@@ -245,7 +254,7 @@ int send_run(sock_t st, shard_t *s)
 	// adaptive timing to hit target rate
 	uint64_t count = 0;
 	uint64_t last_count = count;
-	double last_time = now();
+	double last_time = steady_now();
 	uint32_t delay = 0;
 	int interval = 0;
 	volatile int vi;
@@ -262,18 +271,18 @@ int send_run(sock_t st, shard_t *s)
 		if (send_rate < slow_rate) {
 			// set the initial time difference
 			sleep_time = nsec_per_sec / send_rate;
-			last_time = now() - (1.0 / send_rate);
+			last_time = steady_now() - (1.0 / send_rate);
 		} else {
 			// estimate initial rate
 			for (vi = delay; vi--;)
 				;
-			delay *= 1 / (now() - last_time) /
+			delay *= 1 / (steady_now() - last_time) /
 				 ((double)zconf.rate /
 				  ((double)zconf.senders * zconf.batch));
 			interval = ((double)zconf.rate /
 				    ((double)zconf.senders * zconf.batch)) /
 				   20;
-			last_time = now();
+			last_time = steady_now();
 		}
 	}
 	// Get the initial IP to scan.
@@ -300,7 +309,7 @@ int send_run(sock_t st, shard_t *s)
 		// Adaptive timing delay
 		if (count && delay > 0) {
 			if (send_rate < slow_rate) {
-				double t = now();
+				double t = steady_now();
 				double last_rate = (1.0 / (t - last_time));
 
 				sleep_time *= ((last_rate / send_rate) + 1) / 2;
@@ -316,7 +325,7 @@ int send_run(sock_t st, shard_t *s)
 				for (vi = delay; vi--;)
 					;
 				if (!interval || (count % interval == 0)) {
-					double t = now();
+					double t = steady_now();
 					assert(count > last_count);
 					assert(t > last_time);
 					double multiplier =


### PR DESCRIPTION
This replaces calls to `gettimeofday` with `clock_gettime(CLOCK_MONOTONIC, ...)` in the rate limiting code.
This fixes #706 where ZMap can crash if the host clock goes backwards.

Feel free to suggest a better name/location for the `steady_now` function!