### PR TITLE
Fix 32bit overflow in monitor.c (issue #715)

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -150,7 +150,7 @@ double compute_remaining_time(double age, uint64_t packets_sent, uint64_t iterat
 		}
 		if (zsend.max_index) {
 			double done = (double)packets_sent /
-				      (zsend.max_index * zconf.packet_streams /
+				      ((uint64_t)zsend.max_index * zconf.packet_streams /
 				       zconf.total_shards);
 			remaining[4] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;


### PR DESCRIPTION
Fixes #715.

If number of probes is greater than 1, then any scan above 50% will result in the multiplication in the given line to overflow. This triggers a false minimum comparison, yielding wildly incorrect scan time estimations.

The fix is to cast the 32 bit value to a uint64_t before multiplication, as is done for the other clauses above.

Before fix:
```
$~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 1 > /dev/null
...
 0:05 0% (17h left); send: 291944 58.5 Kp/s (58.4 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%

$:~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 2 > /dev/null
 ...
 0:05 0% (14h left); send: 293616 60.3 Kp/s (58.7 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%

$:~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 10 > /dev/null
 ...
 0:05 0% (12h left); send: 297280 58.9 Kp/s (59.4 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
```

After fix:

```
$~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 1 > /dev/null
 ...
 0:05 0% (17h left); send: 291727 59.2 Kp/s (58.3 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 

$:~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 2 > /dev/null
 ...
 0:05 0% (1d10h left); send: 295202 59.1 Kp/s (59.0 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%

$:~/repos/zmap$ ./src/zmap --dryrun -p 443 -n 100% -u updates.csv -l debug.log -r 60000 -v5 -P 10 > /dev/null
...
 0:05 0% (7d05h left); send: 296584 60.0 Kp/s (59.3 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
```