### PR TITLE
Store link-layer timestamp in icmp_echo_time module

### DIFF
--- a/src/probe_modules/module_icmp_echo_time.c
+++ b/src/probe_modules/module_icmp_echo_time.c
@@ -178,8 +178,18 @@ static void icmp_echo_process_packet(const u_char *packet,
 
 	struct icmp_payload_for_rtt *payload =
 	    (struct icmp_payload_for_rtt *)(((char *)icmp_hdr) + 8);
-	fs_add_uint64(fs, "sent_timestamp_ts", (uint64_t)payload->sent_tv_sec);
-	fs_add_uint64(fs, "sent_timestamp_us", (uint64_t)payload->sent_tv_usec);
+
+	uint64_t sent_timestamp_ts = (uint64_t)payload->sent_tv_sec;
+	uint64_t sent_timestamp_us = (uint64_t)payload->sent_tv_usec;
+	uint64_t recv_timestamp_ts = (uint64_t)ts.tv_sec;
+	uint64_t recv_timestamp_us = (uint64_t)ts.tv_nsec / 1000;
+	uint64_t rtt_us = (recv_timestamp_ts * 1000000 + recv_timestamp_us) - (sent_timestamp_ts * 1000000 + sent_timestamp_us);
+
+	fs_add_uint64(fs, "sent_timestamp_ts", sent_timestamp_ts);
+	fs_add_uint64(fs, "sent_timestamp_us", sent_timestamp_us);
+	fs_add_uint64(fs, "recv_timestamp_ts", recv_timestamp_ts);
+	fs_add_uint64(fs, "recv_timestamp_us", recv_timestamp_us);
+	fs_add_uint64(fs, "rtt_us", rtt_us);
 	fs_add_uint64(fs, "dst_raw", (uint64_t)payload->dst);
 
 	switch (icmp_hdr->icmp_type) {
@@ -221,6 +231,15 @@ static fielddef_t fields[] = {
     {.name = "sent_timestamp_us",
      .type = "int",
      .desc = "microsecond part of sent timestamp"},
+    {.name = "recv_timestamp_ts",
+     .type = "int",
+     .desc = "timestamp of receive probe in seconds since Epoch"},
+    {.name = "recv_timestamp_us",
+     .type = "int",
+     .desc = "microsecond part of receive timestamp"},
+    {.name = "rtt_us",
+     .type = "int",
+     .desc = "round-trip time in microseconds"},
     {.name = "dst_raw",
      .type = "int",
      .desc = "raw destination IP address of sent probe"},
@@ -245,4 +264,4 @@ probe_module_t module_icmp_echo_time = {
     .close = NULL,
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
-    .numfields = 9};
+    .numfields = 12};


### PR DESCRIPTION
Fixes inaccurate RTTs when using the `icmp_echo_time` module (https://github.com/zmap/zmap/issues/562).

This follows up on https://github.com/zmap/zmap/pull/607 which passes the pcap/pf_ring timestamp to the packet handler. The information was there but was seemingly never used.

This adds two fields to the output of the `icmp_echo_time` module based on the capture timestamp: `recv_timestamp_ts` and `recv_timestamp_ns`.

Test:

```bash
./src/zmap -M icmp_echo_time -O json 8.8.8.8 \
  -f sent_timestamp_ts,sent_timestamp_us,timestamp_ts,timestamp_us,recv_timestamp_ts,recv_timestamp_ns > res.json
```

RTT with original timestamp:

```bash
jq '((.timestamp_ts * 1e6 + .timestamp_us) - (.sent_timestamp_ts * 1e6 + .sent_timestamp_us)) / 1e3' res.json
1044.48
```

RTT with link-layer timestamp:

```bash
jq '((.recv_timestamp_ts * 1e6 + .recv_timestamp_ns / 1e3) - (.sent_timestamp_ts * 1e6 + .sent_timestamp_us)) / 1e3' res.json
17.838
```

RTT with ping:

```bash
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=116 time=20.2 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=116 time=18.3 ms
64 bytes from 8.8.8.8: icmp_seq=3 ttl=116 time=16.3 ms
```