### PR TITLE
Use interface with default route on Linux

### DIFF
--- a/src/get_gateway-linux.h
+++ b/src/get_gateway-linux.h
@@ -21,21 +21,6 @@
 
 #define GW_BUFFER_SIZE 64000
 
-char *get_default_iface(void)
-{
-	char errbuf[PCAP_ERRBUF_SIZE];
-	char *iface = pcap_lookupdev(errbuf);
-	if (iface == NULL) {
-		log_fatal(
-		    "send",
-		    "ZMap could not detect your default network interface. "
-		    "You likely do not privileges to open a raw packet socket. "
-		    "Are you running as root or with the CAP_NET_RAW capability? If you are, you "
-		    "may need to manually set interface using the \"-i\" flag.");
-	}
-	return iface;
-}
-
 int read_nl_sock(int sock, char *buf, int buf_len)
 {
 	int msg_len = 0;
@@ -244,6 +229,26 @@ int _get_default_gw(struct in_addr *gw, char *iface)
 		nlhdr = NLMSG_NEXT(nlhdr, nl_len);
 	}
 	return -1;
+}
+
+char *get_default_iface(void)
+{
+	struct in_addr gw;
+	char *iface;
+
+	iface = malloc(IF_NAMESIZE);
+	memset(iface, 0, IF_NAMESIZE);
+
+	if(_get_default_gw(&gw, iface)) {
+		log_fatal(
+		    "send",
+		    "ZMap could not detect your default network interface. "
+		    "You likely do not privileges to open a raw packet socket. "
+		    "Are you running as root or with the CAP_NET_RAW capability? If you are, you "
+		    "may need to manually set interface using the \"-i\" flag.");
+	} else {
+		return iface;
+	}
 }
 
 int get_default_gw(struct in_addr *gw, char *iface)

--- a/src/get_gateway-linux.h
+++ b/src/get_gateway-linux.h
@@ -243,7 +243,7 @@ char *get_default_iface(void)
 		log_fatal(
 		    "send",
 		    "ZMap could not detect your default network interface. "
-		    "You likely do not privileges to open a raw packet socket. "
+		    "You likely do not have sufficient privileges to open a raw packet socket. "
 		    "Are you running as root or with the CAP_NET_RAW capability? If you are, you "
 		    "may need to manually set interface using the \"-i\" flag.");
 	} else {


### PR DESCRIPTION
It seems that patch bf5ed24c1535e0342631cf9ad904fa59720bc46b changed the way zmap finds the default interface.

It used to use `get_default_gw` to find the interface with the default route. Now it uses `pcap_lookupdev` which takes the first interface suitable for packet capture, but does not ensure that it has the default route.

This patch reverts to the old behavior and is consistent with `get_gateway-bsd.h`.