### PR TITLE
Fixed typos in man pages and --help text

### DIFF
--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "June 2017" "ZMap" "zmap"
+.TH "ZMAP" "1" "November 2023" "" ""
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -21,8 +21,8 @@ zmap [ \-p <port> ] [ \-o <outfile> ] [ OPTIONS\.\.\. ] [ ip/hostname/range ]
 IP addresses or DNS hostnames to scan\. Accepts IP ranges in CIDR block notation\. Defaults to 0\.0\.0/8
 .
 .TP
-\fB\-p\fR, \fB\-\-target\-port=port\fR
-TCP or UDP port number to scan (for SYN scans and basic UDP scans)
+\fB\-p\fR, \fB\-\-target\-ports=port(s)\fR
+List of TCP/UDP ports and/or port ranges to scan (e\.g\., 80,443,100\-105)\. Use \'*\' to scan all ports, including port 0\.
 .
 .TP
 \fB\-o\fR, \fB\-\-output\-file=name\fR
@@ -44,7 +44,7 @@ File of individual IP addresses to scan, one\-per line\. This feature allows you
 .
 .TP
 \fB\-r\fR, \fB\-\-rate=pps\fR
-Set the send rate in packets/sec\. Note: when combined with \-\-probes, this is total packets per second, not IPs per second\.
+Set the send rate in packets/sec\. Note: when combined with \-\-probes, this is total packets per second, not IPs per second\. Setting the rate to 0 will scan at full line rate\. Default: 10000 pps\.
 .
 .TP
 \fB\-B\fR, \fB\-\-bandwidth=bps\fR
@@ -71,20 +71,26 @@ How long to continue receiving after sending has completed (default=8)
 Seed used to select address permutation\. Use this if you want to scan addresses in the same order for multiple ZMap runs\.
 .
 .TP
-\fB\-\-shards=N\fR
-Split the scan up into N shards/partitions among different instances of zmap (default=1)\. When sharding, \fB\-\-seed\fR is required\.
-.
-.TP
-\fB\-\-shard=n\fR
-Set which shard to scan (default=0)\. Shards are 0\-indexed in the range [0, N), where N is the total number of shards\. When sharding \fB\-\-seed\fR is required\.
-.
-.TP
 \fB\-P\fR, \fB\-\-probes=n\fR
 Number of probes to send to each IP (default=1)
 .
 .TP
 \fB\-\-retries=n\fR
 Number of times to try resending a packet if the sendto call fails (default=10)
+.
+.TP
+\fB\-\-batch=n\fR
+Number of packets to send in a burst between checks to the ratelimit\. A batch size above 1 allows the sleep\-based rate\-limiter to be used with proportionally higher rates\. This can reduce CPU usage, in exchange for a bursty send rate\. (default=1)
+.
+.SS "SCAN SHARDING"
+.
+.TP
+\fB\-\-shards=N\fR
+Split the scan up into N shards/partitions among different instances of zmap (default=1)\. When sharding, \fB\-\-seed\fR is required\.
+.
+.TP
+\fB\-\-shard=n\fR
+Set which shard to scan (default=0)\. Shards are 0\-indexed in the range [0, N), where N is the total number of shards\. When sharding \fB\-\-seed\fR is required\.
 .
 .SS "NETWORK OPTIONS"
 .
@@ -128,6 +134,10 @@ Select probe module (default=tcp_synscan)
 Arguments to pass to probe module
 .
 .TP
+\fB\-\-probe\-ttl=hops\fR
+Set TTL value for probe IP packets
+.
+.TP
 \fB\-\-list\-output\-fields\fR
 List the fields the selected probe module can send to the output module
 .
@@ -153,6 +163,21 @@ Comma\-separated list of fields to output
 .TP
 \fB\-\-output\-filter\fR
 Specify an output filter over the fields defined by the probe module\. See the output filter section for more details\.
+.
+.TP
+\fB\-\-no\-header\-row\fR
+Excludes any header rows (e\.g\., CSV header fields) from ZMap output\. This is useful if you\'re piping results into another application that expects only data\.
+.
+.SS "OUTPUT OPTIONS"
+Hosts will oftentimes send multiple responses to a probe (either because the scanner doesn\'t send back a RST packet or because the host has a misimplemented TCP stack\. To address this, ZMap will attempt to deduplicate responsive (ip,port) targets\.
+.
+.TP
+\fB\-\-dedup\-method\fR
+Specifies the method ZMap will use to deduplicate responses\. Options are: full, window, and none\. Full deduplication uses a 32\-bit bitmap and guarantees that no duplicates will be emitted\. However, full\-deduplication requires around 500MB of memory for a single port\. We do not support full deduplication for multiple ports\. Window uses a sliding window of a the last (user\-defined) number of responses as set by \-\-dedup\-window\-size\. None will prevent any deduplication\.
+.
+.TP
+\fB\-\-dedup\-window\-size=targets\fR
+Specifies the size of the sliding window of last n target responses to be used for deduplication\. Only applicable if using window deduplication\.
 .
 .SS "LOGGING AND METADATA OPTIONS"
 .

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -187,7 +187,7 @@ targets.
      requires around 500MB of memory for a single port. We do not support full
      deduplication for multiple ports. Window uses a sliding window of a the last
      (user-defined) number of responses as set by --dedup-window-size. None will
-     prevent any duplication
+     prevent any deduplication.
 
    * `--dedup-window-size=targets`:
      Specifies the size of the sliding window of last n target responses to be

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -136,10 +136,10 @@ option "no-header-row"          - "Precludes outputting any header rows in data 
 
 
 section "Response Deduplication"
-option "dedup-method"           - "Specifices how response deduplication should be performed. Options: default, none, full, window"
+option "dedup-method"           - "Specifies how response deduplication should be performed. Options: default, none, full, window"
     typestr="method"
     optional string
-option "dedup-window-size"      - "Specifices window size for how many recent responses to keep in memory for deuplication"
+option "dedup-window-size"      - "Specifies window size for how many recent responses to keep in memory for deuplication"
     typestr="targets"
     default="1000000"
     optional int


### PR DESCRIPTION
- fixed a typo in man pages
    - re-generated the man pages with `ronn` CLI tool
    - verified that the changes took effect with `man zmap`
- fixed a typo in the `--help` text
    - verified the changes took effect by re-compiling and running `zmap --version`