### PR TITLE
Update manual pages to add details to --probes to contrast with --retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ CMakeCache.txt
 install_manifest.txt
 _CPack_Packages/*
 src/ztests
+*.DS_Store

--- a/src/zblocklist.1
+++ b/src/zblocklist.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZBLACKLIST" "1" "June 2017" "ZMap" "zblocklist"
+.TH "ZBLOCKLIST" "1" "November 2023" "ZMap" "zblocklist"
 .
 .SH "NAME"
-\fBzblocklist\fR \- zmap IP blacklist tool
+\fBzblocklist\fR \- zmap IP blocklist tool
 .
 .SH "SYNOPSIS"
-zblocklist [ \-b <blacklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
+zblocklist [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
 .
 .SH "DESCRIPTION"
 \fIZBlacklist\fR is a network tool for limiting and deduplicating a list of IP addresses using a blocklist or allowlist\.
@@ -18,7 +18,7 @@ zblocklist [ \-b <blacklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
 .
 .TP
 \fB\-b\fR, \fB\-\-blocklist\-file=path\fR
-File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblacklist\.conf\fR for this purpose\.
+File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblocklist\.conf\fR for this purpose\.
 .
 .TP
 \fB\-w\fR, \fB\-\-allowlist\-file=name\fR

--- a/src/zblocklist.1.html
+++ b/src/zblocklist.1.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='content-type' value='text/html;charset=utf8'>
   <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
-  <title>ziterate(1) - ZMap IP permutation generation file</title>
+  <title>zblocklist(1) - zmap IP blocklist tool</title>
   <style type='text/css' media='all'>
   /* style: man */
   body#manpage {margin:0}
@@ -60,33 +60,30 @@
   </div>
 
   <ol class='man-decor man-head man head'>
-    <li class='tl'>ziterate(1)</li>
-    <li class='tc'>ziterate</li>
-    <li class='tr'>ziterate(1)</li>
+    <li class='tl'>zblocklist(1)</li>
+    <li class='tc'>zblocklist</li>
+    <li class='tr'>zblocklist(1)</li>
   </ol>
 
   <h2 id="NAME">NAME</h2>
 <p class="man-name">
-  <code>ziterate</code> - <span class="man-whatis">ZMap IP permutation generation file</span>
+  <code>zblocklist</code> - <span class="man-whatis">zmap IP blocklist tool</span>
 </p>
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p>ziterate [ -b &lt;blocklist&gt; ] [ -w &lt;allowlist&gt; ] [ OPTIONS... ]</p>
+<p>zblocklist [ -b &lt;blocklist&gt; ] [ -w &lt;allowlist&gt; ] [ OPTIONS... ]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
-<p><em>ZIterate</em> is a network tool that will produce IPv4 addresses in a psuedorandom
-order similar to how ZMap generates random addresses to be scanned.</p>
+<p><em>ZBlacklist</em> is a network tool for limiting and deduplicating a list of
+IP addresses using a blocklist or allowlist.</p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
 
 <dl>
-<dt> <code>-p</code>, <code>--target-ports=port(s)</code></dt><dd><p> List of TCP/UDP ports and/or port ranges to scan. (e.g., 80,443,100-105).
- Use '*' to scan all ports, including port 0. If no port is specified,
- ziterate will output only IPs.</p></dd>
 <dt> <code>-b</code>, <code>--blocklist-file=path</code></dt><dd><p> File of subnets to exclude, in CIDR notation, one-per line. It is
  recommended you use this to exclude RFC 1918 addresses, multicast, IANA
  reserved space, and other IANA special-purpose addresses. An example
@@ -96,25 +93,18 @@ subnets will be excluded.</p></dd>
 <dt><code>-l</code>, <code>--log-file=name</code></dt><dd><p>File to log to.</p></dd>
 <dt><code>--disable-syslog</code></dt><dd><p>Disable logging messages to syslog.</p></dd>
 <dt><code>-v</code>, <code>--verbosity</code></dt><dd><p>Level of log detail (0-5, default=3)</p></dd>
-<dt><code>--ignore-blocklist-errors</code></dt><dd><p>Ignore invalid entries in the blocklist. Default is false.</p></dd>
-<dt><code>--seed=n</code></dt><dd><p>Seed used to select address permutation.</p></dd>
-<dt><code>-n</code>, <code>--max-targets=n</code></dt><dd><p>Cap number of IPs to generate (as a number or a percentage of the address space)</p></dd>
-</dl>
-
-
-<h3 id="SHARDING">SHARDING</h3>
-
-<dl>
-<dt><code>--shards=n</code></dt><dd><p>Total number of shards.</p></dd>
-<dt><code>--shard=n</code></dt><dd><p>Shard this scan is targeting. Zero indexed.</p></dd>
+<dt><code>--no-duplicate-checking</code></dt><dd><p>Don't deduplicate input addresses. Default is false.</p></dd>
+<dt><code>--ignore-blocklist-errors</code></dt><dd><p>Ignore invalid, malformed, or unresolvable entries in the
+blocklist/allowlist. Default is false.</p></dd>
+<dt><code>--ignore-input-errors</code></dt><dd><p>Don't print invalid entries in the input. Default is false.</p></dd>
 </dl>
 
 
 <h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
 
 <dl>
-<dt><code>-h</code>, <code>--help</code></dt><dd><p>Print help text and exit.</p></dd>
-<dt><code>-V</code>, <code>--version</code></dt><dd><p>Print version and exit.</p></dd>
+<dt><code>-h</code>, <code>--help</code></dt><dd><p>Print help and exit</p></dd>
+<dt><code>-V</code>, <code>--version</code></dt><dd><p>Print version and exit</p></dd>
 </dl>
 
 
@@ -122,7 +112,7 @@ subnets will be excluded.</p></dd>
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
     <li class='tc'>November 2023</li>
-    <li class='tr'>ziterate(1)</li>
+    <li class='tr'>zblocklist(1)</li>
   </ol>
 
   </div>

--- a/src/ziterate.1
+++ b/src/ziterate.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZITERATE" "1" "June 2017" "ZMap" "ziterate"
+.TH "ZITERATE" "1" "November 2023" "ZMap" "ziterate"
 .
 .SH "NAME"
 \fBziterate\fR \- ZMap IP permutation generation file
@@ -17,8 +17,12 @@ ziterate [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
 .SS "BASIC OPTIONS"
 .
 .TP
+\fB\-p\fR, \fB\-\-target\-ports=port(s)\fR
+List of TCP/UDP ports and/or port ranges to scan\. (e\.g\., 80,443,100\-105)\. Use \'*\' to scan all ports, including port 0\. If no port is specified, ziterate will output only IPs\.
+.
+.TP
 \fB\-b\fR, \fB\-\-blocklist\-file=path\fR
-File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblacklist\.conf\fR for this purpose\.
+File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblocklist\.conf\fR for this purpose\.
 .
 .TP
 \fB\-w\fR, \fB\-\-allowlist\-file=name\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -72,7 +72,7 @@ Seed used to select address permutation\. Use this if you want to scan addresses
 .
 .TP
 \fB\-P\fR, \fB\-\-probes=n\fR
-Number of probes to send to each IP (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \-\-retries which just gives the number of attempts to send a single probe\.
+Number of probes to send to each IP/Port pair (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \-\-retries which just gives the number of attempts to send a single probe\.
 .
 .TP
 \fB\-\-retries=n\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -7,7 +7,7 @@
 \fBzmap\fR \- The Fast Internet Scanner
 .
 .SH "SYNOPSIS"
-zmap [ \-p <port> ] [ \-o <outfile> ] [ OPTIONS\.\.\. ] [ ip/hostname/range ]
+zmap [ \-p <port(s)> ] [ \-o <outfile> ] [ OPTIONS\.\.\. ] [ ip/hostname/range ]
 .
 .SH "DESCRIPTION"
 \fIZMap\fR is a network tool for scanning the entire IPv4 address space (or large samples)\. ZMap is capable of scanning the entire Internet in around 45 minutes on a gigabit network connection, reaching ~98% theoretical line speed\.
@@ -72,7 +72,7 @@ Seed used to select address permutation\. Use this if you want to scan addresses
 .
 .TP
 \fB\-P\fR, \fB\-\-probes=n\fR
-Number of probes to send to each IP/Port pair (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \-\-retries which just gives the number of attempts to send a single probe\.
+Number of probes to send to each IP/Port pair (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \fB\-\-retries\fR which just gives the number of attempts to send a single probe on the source NIC\.
 .
 .TP
 \fB\-\-retries=n\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "November 2023" "" ""
+.TH "ZMAP" "1" "November 2023" "ZMap" "zmap"
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -72,7 +72,7 @@ Seed used to select address permutation\. Use this if you want to scan addresses
 .
 .TP
 \fB\-P\fR, \fB\-\-probes=n\fR
-Number of probes to send to each IP (default=1)
+Number of probes to send to each IP (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \-\-retries which just gives the number of attempts to send a single probe\.
 .
 .TP
 \fB\-\-retries=n\fR

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>zmap(1) - The Fast Internet Scanner</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#OPTIONS">OPTIONS</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>zmap(1)</li>
+    <li class='tc'>zmap</li>
+    <li class='tr'>zmap(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>zmap</code> - <span class="man-whatis">The Fast Internet Scanner</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p>zmap [ -p &lt;port> ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]</p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p><em>ZMap</em> is a network tool for scanning the entire IPv4 address space (or large
+samples).  ZMap is capable of scanning the entire Internet in around 45 minutes
+on a gigabit network connection, reaching ~98% theoretical line speed.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
+
+<dl>
+<dt> <code>ip</code>/<code>hostname</code>/<code>range</code></dt><dd><p> IP addresses or DNS hostnames to scan. Accepts IP ranges in CIDR block
+ notation. Defaults to 0.0.0/8</p></dd>
+<dt> <code>-p</code>, <code>--target-ports=port(s)</code></dt><dd><p> List of TCP/UDP ports and/or port ranges to scan (e.g., 80,443,100-105).
+ Use '*' to scan all ports, including port 0.</p></dd>
+<dt> <code>-o</code>, <code>--output-file=name</code></dt><dd><p> When using an output module that uses a file, write results to this file.
+ Use - for stdout.</p></dd>
+<dt> <code>-b</code>, <code>--blocklist-file=path</code></dt><dd><p> File of subnets to exclude, in CIDR notation, one-per line. It is
+ recommended you use this to exclude RFC 1918 addresses, multicast, IANA
+ reserved space, and other IANA special-purpose addresses. An example
+ blocklist file <strong>blocklist.conf</strong> for this purpose.</p></dd>
+<dt> <code>-w</code>, <code>--allowlist-file=path</code></dt><dd><p>File of subnets to scan, in CIDR notation, one-per line. Specifying a
+allowlist file is equivalent to specifying to ranges directly on the command
+line interface, but allows specifying a large number of subnets. Note:
+if you are specifying a large number of individual IP addresses (more than
+10 million), you should instead use <code>--list-of-ips-file</code>.</p></dd>
+<dt> <code>-I</code>, <code>--list-of-ips-file=path</code></dt><dd><p>File of individual IP addresses to scan, one-per line. This feature allows you
+to scan a large number of unrelated addresses. If you have a small number of IPs,
+it is faster to specify these on the command
+line or by using <code>--allowlist-file</code>. This should only be used when scanning more than
+10 million addresses. When used in with --allowlist-path, only hosts in the intersection
+of both sets will be scanned. Hosts specified here, but included in the blocklist will
+be excluded.</p></dd>
+</dl>
+
+
+<h3 id="SCAN-OPTIONS">SCAN OPTIONS</h3>
+
+<dl>
+<dt> <code>-r</code>, <code>--rate=pps</code></dt><dd><p> Set the send rate in packets/sec. Note: when combined with --probes,  this is
+ total packets per second, not IPs per second. Setting the rate to 0 will scan
+ at full line rate. Default: 10000 pps.</p></dd>
+<dt> <code>-B</code>, <code>--bandwidth=bps</code></dt><dd><p> Set the send rate in bits/second (supports suffixes G, M, and K (e.g. -B
+ 10M for 10 mbps). This overrides the --rate flag.</p></dd>
+<dt> <code>-n</code>, <code>--max-targets=n</code></dt><dd><p> Cap the number of targets to probe. This can either be a number (e.g. -n
+ 1000) or a percentage (e.g. -n 0.1%) of the scannable address space
+ (after excluding blocklist)</p></dd>
+<dt> <code>-N</code>, <code>--max-results=n</code></dt><dd><p> Exit after receiving this many results</p></dd>
+<dt> <code>-t</code>, <code>--max-runtime=secs</code></dt><dd><p> Cap the length of time for sending packets</p></dd>
+<dt> <code>-c</code>, <code>--cooldown-time=secs</code></dt><dd><p> How long to continue receiving after sending has completed (default=8)</p></dd>
+<dt> <code>-e</code>, <code>--seed=n</code></dt><dd><p> Seed used to select address permutation. Use this if you want to scan
+ addresses in the same order for multiple ZMap runs.</p></dd>
+<dt> <code>-P</code>, <code>--probes=n</code></dt><dd><p> Number of probes to send to each IP (default=1). Since ZMap composes Ethernet
+ frames directly, probes can be lost en-route to destination. Increasing the
+ --probes increases the chance that an online host will receive a probe in an
+ unreliable network. This is contrasted with --retries which just gives the
+ number of attempts to send a single probe.</p></dd>
+<dt> <code>--retries=n</code></dt><dd><p> Number of times to try resending a packet if the sendto call fails (default=10)</p></dd>
+<dt> <code>--batch=n</code></dt><dd><p> Number of packets to send in a burst between checks to the ratelimit. A
+ batch size above 1 allows the sleep-based rate-limiter to be used with
+ proportionally higher rates. This can reduce CPU usage, in exchange for a
+ bursty send rate. (default=1)</p></dd>
+</dl>
+
+
+<h3 id="SCAN-SHARDING">SCAN SHARDING</h3>
+
+<dl>
+<dt> <code>--shards=N</code></dt><dd><p> Split the scan up into N shards/partitions among different instances of
+ zmap (default=1). When sharding, <strong>--seed</strong> is required.</p></dd>
+<dt> <code>--shard=n</code></dt><dd><p> Set which shard to scan (default=0). Shards are 0-indexed in the range
+ [0, N), where N is the    total number of shards. When sharding
+ <strong>--seed</strong> is required.</p></dd>
+</dl>
+
+
+<h3 id="NETWORK-OPTIONS">NETWORK OPTIONS</h3>
+
+<dl>
+<dt> <code>-s</code>, <code>--source-port=port|range</code></dt><dd><p> Source port(s) to send packets from</p></dd>
+<dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
+ 10.0.0.1-10.0.0.9)</p></dd>
+<dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>
+<dt> <code>--source-mac=addr</code></dt><dd><p> Source MAC address to send packets from (in case auto-detection fails)</p></dd>
+<dt> <code>-i</code>, <code>--interface=name</code></dt><dd><p> Network interface to use</p></dd>
+<dt> <code>-X</code>, <code>--iplayer</code></dt><dd><p> Send IP layer packets instead of ethernet packets (for non-Ethernet interface)</p></dd>
+</dl>
+
+
+<h3 id="PROBE-OPTIONS">PROBE OPTIONS</h3>
+
+<p>ZMap allows users to specify and write their own probe modules. Probe modules
+are responsible for generating probe packets to send, and processing responses
+from hosts.</p>
+
+<dl>
+<dt> <code>--list-probe-modules</code></dt><dd><p> List available probe modules (e.g. tcp_synscan)</p></dd>
+<dt> <code>-M</code>, <code>--probe-module=name</code></dt><dd><p> Select probe module (default=tcp_synscan)</p></dd>
+<dt> <code>--probe-args=args</code></dt><dd><p> Arguments to pass to probe module</p></dd>
+<dt> <code>--probe-ttl=hops</code></dt><dd><p> Set TTL value for probe IP packets</p></dd>
+<dt> <code>--list-output-fields</code></dt><dd><p> List the fields the selected probe module can send to the output module</p></dd>
+</dl>
+
+
+<h3 id="OUTPUT-OPTIONS">OUTPUT OPTIONS</h3>
+
+<p>ZMap allows users to specify and write their own output modules for use with
+ZMap. Output modules are responsible for processing the fieldsets returned by
+the probe module, and outputting them to the user. Users can specify output
+fields, and write filters over the output fields.</p>
+
+<dl>
+<dt> <code>--list-output-modules</code></dt><dd><p> List available output modules (e.g. csv)</p></dd>
+<dt> <code>-O</code>, <code>--output-module=name</code></dt><dd><p> Select output module (default=csv)</p></dd>
+<dt> <code>--output-args=args</code></dt><dd><p> Arguments to pass to output module</p></dd>
+<dt> <code>-f</code>, <code>--output-fields=fields</code></dt><dd><p> Comma-separated list of fields to output</p></dd>
+<dt> <code>--output-filter</code></dt><dd><p> Specify an output filter over the fields defined by the probe module. See
+ the output filter section for more details.</p></dd>
+<dt> <code>--no-header-row</code></dt><dd><p> Excludes any header rows (e.g., CSV header fields) from ZMap output. This is
+ useful if you're piping results into another application that expects only
+ data.</p></dd>
+</dl>
+
+
+<h3 id="OUTPUT-OPTIONS">OUTPUT OPTIONS</h3>
+
+<p>Hosts will oftentimes send multiple responses to a probe (either because the
+scanner doesn't send back a RST packet or because the host has a misimplemented
+TCP stack. To address this, ZMap will attempt to deduplicate responsive (ip,port)
+targets.</p>
+
+<dl>
+<dt> <code>--dedup-method</code></dt><dd><p> Specifies the method ZMap will use to deduplicate responses. Options are:
+ full, window, and none. Full deduplication uses a 32-bit bitmap and
+ guarantees that no duplicates will be emitted. However, full-deduplication
+ requires around 500MB of memory for a single port. We do not support full
+ deduplication for multiple ports. Window uses a sliding window of a the last
+ (user-defined) number of responses as set by --dedup-window-size. None will
+ prevent any deduplication.</p></dd>
+<dt> <code>--dedup-window-size=targets</code></dt><dd><p> Specifies the size of the sliding window of last n target responses to be
+ used for deduplication. Only applicable if using window deduplication.</p></dd>
+</dl>
+
+
+<h3 id="LOGGING-AND-METADATA-OPTIONS">LOGGING AND METADATA OPTIONS</h3>
+
+<dl>
+<dt> <code>-q</code>, <code>--quiet</code></dt><dd><p> Do not print status updates once per second</p></dd>
+<dt> <code>-v</code>, <code>--verbosity=n</code></dt><dd><p> Level of log detail (0-5, default=3)</p></dd>
+<dt> <code>-l</code>, <code>--log-file=filename</code></dt><dd><p> Output file for log messages. By default, stderr.</p></dd>
+<dt> <code>-m</code>, <code>--metadata-file=filename</code></dt><dd><p> Output file for scan metadata (JSON)</p></dd>
+<dt> <code>-L</code>, <code>--log-directory</code></dt><dd><p> Write log entries to a timestamped file in this directory</p></dd>
+<dt> <code>-u</code>, <code>--status-updates-file</code></dt><dd><p> Write scan progress updates to CSV file"</p></dd>
+<dt> <code>--disable-syslog</code></dt><dd><p> Disables logging messages to syslog</p></dd>
+<dt> <code>--notes</code></dt><dd><p> Inject user-specified notes into scan metadata</p></dd>
+<dt> <code>--user-metadata</code></dt><dd><p> Inject user-specified JSON metadata into scan metadata</p></dd>
+</dl>
+
+
+<h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
+
+<dl>
+<dt> <code>-T</code>, <code>--sender-threads=n</code></dt><dd><p> Threads used to send packets. ZMap will attempt to detect the optimal
+ number of send threads based on the number of processor cores.</p></dd>
+<dt> <code>-C</code>, <code>--config=filename</code></dt><dd><p> Read a configuration file, which can specify any other options.</p></dd>
+<dt> <code>-d</code>, <code>--dryrun</code></dt><dd><p> Print out each packet to stdout instead of sending it (useful for
+ debugging)</p></dd>
+<dt> <code>--max-sendto-failures</code></dt><dd><p> Maximum NIC sendto failures before scan is aborted</p></dd>
+<dt> <code>--min-hitrate</code></dt><dd><p> Minimum hitrate that scan can hit before scan is aborted</p></dd>
+<dt> <code>--cores</code></dt><dd><p> Comma-separated list of cores to pin to</p></dd>
+<dt> <code>--ignore-blocklist-errors</code></dt><dd><p>  Ignore invalid, malformed, or unresolvable entries in allowlist/blocklist file.
+  Replaces the pre-v3.x <code>--ignore-invalid-hosts</code> option.</p></dd>
+<dt> <code>-h</code>, <code>--help</code></dt><dd><p> Print help and exit</p></dd>
+<dt> <code>-V</code>, <code>--version</code></dt><dd><p> Print version and exit</p></dd>
+</dl>
+
+
+<h3 id="OUTPUT-FILTERS">OUTPUT FILTERS</h3>
+
+<p>Results generated by a probe module can be filtered before being passed to the
+output module. Filters are defined over the output fields of a probe module.
+Filters are written in a simple filtering language, similar to SQL, and are
+passed to ZMap using the <code>--output-filter</code> option. Output filters are commonly
+used to filter out duplicate results, or to only pass only successful responses
+to the output module.</p>
+
+<p>Filter expressions are of the form <code>&lt;fieldname> &lt;operation> &lt;value></code>. The type of
+<code>&lt;value></code> must be either a string or unsigned integer literal, and match the type
+of <code>&lt;fieldname></code>. The valid operations for integer comparisons are = !=, <var>, </var>,
+<var>=, </var>=. The operations for string comparisons are =, !=. The
+<code>--list-output-fields</code> flag will print what fields and types are available for
+the selected probe module, and then exit.</p>
+
+<p>Compound filter expressions may be constructed by combining filter expressions
+using parenthesis to specify order of operations, the &amp;&amp; (logical AND) and ||
+(logical OR) operators.</p>
+
+<p>For example, a filter for only successful, non-duplicate responses would be
+written as: <code>--output-filter="success = 1 &amp;&amp; repeat = 0"</code></p>
+
+<h3 id="UDP-PROBE-MODULE-OPTIONS">UDP PROBE MODULE OPTIONS</h3>
+
+<p>These arguments are all passed using the <code>--probe-args=args</code> option. Only one
+argument may be passed at a time.</p>
+
+<dl>
+<dt> <code>file:/path/to/file</code></dt><dd><p> Path to payload file to send to each host over UDP.</p></dd>
+<dt> <code>template:/path/to/template</code></dt><dd><p> Path to template file. For each destination host, the template file is
+ populated, set as the UDP payload, and sent.</p></dd>
+<dt> <code>text:&lt;text></code></dt><dd><p> ASCII text to send to each destination host</p></dd>
+<dt> <code>hex:&lt;hex></code></dt><dd><p>Hex-encoded binary to send to each destination host</p></dd>
+<dt> <code>template-fields</code></dt><dd><p> Print information about the allowed template fields and exit.</p></dd>
+</dl>
+
+
+<h3 id="MID-SCAN-CHANGES">MID-SCAN CHANGES</h3>
+
+<p>You can change the rate at which ZMap is scanning mid-scan by sending SIGUSR1 (increase)
+and SIGUSR2 (decrease) signals to ZMap. These will result in the scan rate increasing or
+decreasing by 5%.</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'>ZMap</li>
+    <li class='tc'>November 2023</li>
+    <li class='tr'>zmap(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -72,7 +72,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p>zmap [ -p &lt;port> ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]</p>
+<p>zmap [ -p &lt;port(s)&gt; ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -129,8 +129,8 @@ be excluded.</p></dd>
 <dt> <code>-P</code>, <code>--probes=n</code></dt><dd><p> Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet
  frames directly, probes can be lost en-route to destination. Increasing the
  --probes increases the chance that an online host will receive a probe in an
- unreliable network. This is contrasted with --retries which just gives the
- number of attempts to send a single probe.</p></dd>
+ unreliable network. This is contrasted with <code>--retries</code> which just gives the
+ number of attempts to send a single probe on the source NIC.</p></dd>
 <dt> <code>--retries=n</code></dt><dd><p> Number of times to try resending a packet if the sendto call fails (default=10)</p></dd>
 <dt> <code>--batch=n</code></dt><dd><p> Number of packets to send in a burst between checks to the ratelimit. A
  batch size above 1 allows the sleep-based rate-limiter to be used with

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -126,7 +126,7 @@ be excluded.</p></dd>
 <dt> <code>-c</code>, <code>--cooldown-time=secs</code></dt><dd><p> How long to continue receiving after sending has completed (default=8)</p></dd>
 <dt> <code>-e</code>, <code>--seed=n</code></dt><dd><p> Seed used to select address permutation. Use this if you want to scan
  addresses in the same order for multiple ZMap runs.</p></dd>
-<dt> <code>-P</code>, <code>--probes=n</code></dt><dd><p> Number of probes to send to each IP (default=1). Since ZMap composes Ethernet
+<dt> <code>-P</code>, <code>--probes=n</code></dt><dd><p> Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet
  frames directly, probes can be lost en-route to destination. Increasing the
  --probes increases the chance that an online host will receive a probe in an
  unreliable network. This is contrasted with --retries which just gives the

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -79,7 +79,11 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      addresses in the same order for multiple ZMap runs.
 
    * `-P`, `--probes=n`:
-     Number of probes to send to each IP (default=1)
+     Number of probes to send to each IP (default=1). Since ZMap composes Ethernet 
+     frames directly, probes can be lost en-route to destination. Increasing the
+     --probes increases the chance that an online host will receive a probe in an
+     unreliable network.
+
 
    * `--retries=n`:
      Number of times to try resending a packet if the sendto call fails (default=10)

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -3,7 +3,7 @@ zmap(1) - The Fast Internet Scanner
 
 ## SYNOPSIS
 
-zmap [ -p &lt;port> ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]
+zmap [ -p &lt;port(s)&gt; ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]
 
 ## DESCRIPTION
 
@@ -82,9 +82,8 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet 
      frames directly, probes can be lost en-route to destination. Increasing the
      --probes increases the chance that an online host will receive a probe in an
-     unreliable network. This is contrasted with --retries which just gives the 
-     number of attempts to send a single probe.
-
+     unreliable network. This is contrasted with `--retries` which just gives the
+     number of attempts to send a single probe on the source NIC.
 
    * `--retries=n`:
      Number of times to try resending a packet if the sendto call fails (default=10)

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -79,7 +79,7 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      addresses in the same order for multiple ZMap runs.
 
    * `-P`, `--probes=n`:
-     Number of probes to send to each IP (default=1). Since ZMap composes Ethernet 
+     Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet 
      frames directly, probes can be lost en-route to destination. Increasing the
      --probes increases the chance that an online host will receive a probe in an
      unreliable network. This is contrasted with --retries which just gives the 

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -82,7 +82,8 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      Number of probes to send to each IP (default=1). Since ZMap composes Ethernet 
      frames directly, probes can be lost en-route to destination. Increasing the
      --probes increases the chance that an online host will receive a probe in an
-     unreliable network.
+     unreliable network. This is contrasted with --retries which just gives the 
+     number of attempts to send a single probe.
 
 
    * `--retries=n`:

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -49,7 +49,7 @@ option "max-runtime"            t "Cap length of time for sending packets"
 option "max-results"            N "Cap number of results to return"
     typestr="n"
     optional int
-option "probes"                 P "Number of probes to send to each IP"
+option "probes"                 P "Number of probes to send to each IP/Port pair"
     typestr="n"
     default="1"
     optional int

--- a/src/ztee.1
+++ b/src/ztee.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZTEE" "1" "September 2017" "ZMap" "ztee"
+.TH "ZTEE" "1" "November 2023" "ZMap" "ztee"
 .
 .SH "NAME"
 \fBztee\fR \- output buffer and splitter

--- a/src/ztee.1.html
+++ b/src/ztee.1.html
@@ -120,7 +120,7 @@ in combination with <code>--raw</code>.</p></dd>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>September 2017</li>
+    <li class='tc'>November 2023</li>
     <li class='tr'>ztee(1)</li>
   </ol>
 


### PR DESCRIPTION
- added details to `--probes` to contrast with `--retries`
- re-generated manual pages with `make manpages`
- added `.DS_Store` to `.gitignore`. Looks like it can be auto-generated on MacOS, don't want that slipping into the repo