### PR TITLE
updated Fedora dependencies to having Judy-devel since the prior pkg doesn't exist in latest fedora

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Install the required dependencies with the following commands.
 
 * On RHEL- and Fedora-based systems (including CentOS):
    ```sh
-   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel Judy-devel
+   sudo yum install gcc cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel Judy-devel
    ```
 
 * On macOS systems (using [Homebrew](https://brew.sh/)):

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Install the required dependencies with the following commands.
 
 * On RHEL- and Fedora-based systems (including CentOS):
    ```sh
-   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel libjudy-devel
+   sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel Judy-devel
    ```
 
 * On macOS systems (using [Homebrew](https://brew.sh/)):


### PR DESCRIPTION
## Changes
- updates the dependencies for `fedora` to use `Judy-devel` since that is the name of the pkg in the latest `fedora`
- added `gcc` since `cmake .` couldn't find a C compiler without that


## Before/After Change
In `fedora:latest`, `libjudy-devel` doesn't seem to be in the package manager
```shell
[root@91cc5934e0ff /]# sudo yum install cmake gmp-devel gengetopt libpcap-devel flex byacc json-c-devel libunistring-devel libjudy-devel
Last metadata expiration check: 0:00:12 ago on Thu Nov 16 23:09:57 2023.
No match for argument: libjudy-devel
Error: Unable to find a match: libjudy-devel
[root@91cc5934e0ff /]#
```
But if you use `Judy-devel`, it works. We also need `gcc` as well
```shell
[root@91cc5934e0ff /]# yum search Judy-devel
Last metadata expiration check: 0:24:10 ago on Thu Nov 16 23:09:57 2023.
========================== Name Exactly Matched: Judy-devel ==========================
Judy-devel.aarch64 : Development libraries and headers for Judy
```
## Testing
Tested I can compile from source on latest `fedora` with these dependencies

