### PR TITLE
Set default senders as min(4, number of cores on host)

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -44,6 +44,14 @@ int max_int(int a, int b)
 	return b;
 }
 
+int min_int(int a, int b)
+{
+	if (a >= b) {
+		return b;
+	}
+	return a;
+}
+
 void enforce_range(const char *name, int v, int min, int max)
 {
 	if (check_range(v, min, max) == EXIT_FAILURE) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -24,6 +24,7 @@
 #include "types.h"
 
 int max_int(int a, int b);
+int min_int(int a, int b);
 
 uint32_t parse_max_hosts(char *max_targets);
 void enforce_range(const char *name, int v, int min, int max);

--- a/src/zblocklist.1
+++ b/src/zblocklist.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZBLOCKLIST" "1" "November 2023" "ZMap" "zblocklist"
+.TH "ZBLOCKLIST" "1" "August 2021" "ZMap" "zblocklist"
 .
 .SH "NAME"
 \fBzblocklist\fR \- zmap IP blocklist tool

--- a/src/zblocklist.1.html
+++ b/src/zblocklist.1.html
@@ -111,7 +111,7 @@ blocklist/allowlist. Default is false.</p></dd>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>November 2023</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>zblocklist(1)</li>
   </ol>
 

--- a/src/ziterate.1
+++ b/src/ziterate.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZITERATE" "1" "November 2023" "ZMap" "ziterate"
+.TH "ZITERATE" "1" "September 2023" "ZMap" "ziterate"
 .
 .SH "NAME"
 \fBziterate\fR \- ZMap IP permutation generation file

--- a/src/ziterate.1.html
+++ b/src/ziterate.1.html
@@ -121,7 +121,7 @@ subnets will be excluded.</p></dd>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>November 2023</li>
+    <li class='tc'>September 2023</li>
     <li class='tr'>ziterate(1)</li>
   </ol>
 

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -221,7 +221,7 @@ Inject user\-specified JSON metadata into scan metadata
 .
 .TP
 \fB\-T\fR, \fB\-\-sender\-threads=n\fR
-Threads used to send packets\. ZMap will attempt to detect the optimal number of send threads based on the number of processor cores\. Defaults to min(4, number of processor cores on host)\.
+Threads used to send packets\. ZMap will attempt to detect the optimal number of send threads based on the number of processor cores\. Defaults to min(4, number of processor cores on host \- 1)\.
 .
 .TP
 \fB\-C\fR, \fB\-\-config=filename\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "November 2023" "ZMap" "zmap"
+.TH "ZMAP" "1" "December 2023" "ZMap" "zmap"
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -221,7 +221,7 @@ Inject user\-specified JSON metadata into scan metadata
 .
 .TP
 \fB\-T\fR, \fB\-\-sender\-threads=n\fR
-Threads used to send packets\. ZMap will attempt to detect the optimal number of send threads based on the number of processor cores\.
+Threads used to send packets\. ZMap will attempt to detect the optimal number of send threads based on the number of processor cores\. Defaults to min(4, number of processor cores on host)\.
 .
 .TP
 \fB\-C\fR, \fB\-\-config=filename\fR

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -238,7 +238,7 @@ targets.</p>
 <dl>
 <dt> <code>-T</code>, <code>--sender-threads=n</code></dt><dd><p> Threads used to send packets. ZMap will attempt to detect the optimal
  number of send threads based on the number of processor cores. Defaults to
- min(4, number of processor cores on host).</p></dd>
+ min(4, number of processor cores on host - 1).</p></dd>
 <dt> <code>-C</code>, <code>--config=filename</code></dt><dd><p> Read a configuration file, which can specify any other options.</p></dd>
 <dt> <code>-d</code>, <code>--dryrun</code></dt><dd><p> Print out each packet to stdout instead of sending it (useful for
  debugging)</p></dd>

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -237,7 +237,8 @@ targets.</p>
 
 <dl>
 <dt> <code>-T</code>, <code>--sender-threads=n</code></dt><dd><p> Threads used to send packets. ZMap will attempt to detect the optimal
- number of send threads based on the number of processor cores.</p></dd>
+ number of send threads based on the number of processor cores. Defaults to
+ min(4, number of processor cores on host).</p></dd>
 <dt> <code>-C</code>, <code>--config=filename</code></dt><dd><p> Read a configuration file, which can specify any other options.</p></dd>
 <dt> <code>-d</code>, <code>--dryrun</code></dt><dd><p> Print out each packet to stdout instead of sending it (useful for
  debugging)</p></dd>
@@ -298,7 +299,7 @@ decreasing by 5%.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>November 2023</li>
+    <li class='tc'>December 2023</li>
     <li class='tr'>zmap(1)</li>
   </ol>
 

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -230,7 +230,8 @@ targets.
 
    * `-T`, `--sender-threads=n`:
      Threads used to send packets. ZMap will attempt to detect the optimal
-     number of send threads based on the number of processor cores.
+     number of send threads based on the number of processor cores. Defaults to
+     min(4, number of processor cores on host).
 
    * `-C`, `--config=filename`:
      Read a configuration file, which can specify any other options.

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -79,7 +79,7 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      addresses in the same order for multiple ZMap runs.
 
    * `-P`, `--probes=n`:
-     Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet 
+     Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet
      frames directly, probes can be lost en-route to destination. Increasing the
      --probes increases the chance that an online host will receive a probe in an
      unreliable network. This is contrasted with `--retries` which just gives the
@@ -231,7 +231,7 @@ targets.
    * `-T`, `--sender-threads=n`:
      Threads used to send packets. ZMap will attempt to detect the optimal
      number of send threads based on the number of processor cores. Defaults to
-     min(4, number of processor cores on host).
+     min(4, number of processor cores on host - 1).
 
    * `-C`, `--config=filename`:
      Read a configuration file, which can specify any other options.

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -943,7 +943,7 @@ int main(int argc, char *argv[])
 	if (args.sender_threads_given) {
 		zconf.senders = args.sender_threads_arg;
 	} else {
-		zconf.senders = MIN(get_num_cores(), 4);
+		zconf.senders = min_int(get_num_cores(), 4);
 	}
 	if (2 * zconf.senders >= zsend.max_targets) {
 		log_warn(

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -951,7 +951,6 @@ int main(int argc, char *argv[])
 		    "too few targets relative to senders, dropping to one sender");
 		zconf.senders = 1;
 	}
-	log_warn("zmap", "num cores = %d\n", zconf.senders);
 #else
 	zconf.senders = args.sender_threads_arg;
 #endif

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -190,7 +190,7 @@ option "min-hitrate"            - "Minimum hitrate that scan can hit before scan
 
 option "sender-threads"         T "Threads used to send packets"
     typestr="n"
-    default="min(4, number of cores on host)"
+    default="4"
     optional int
 
 option "cores"                  - "Comma-separated list of cores to pin to"

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -190,7 +190,7 @@ option "min-hitrate"            - "Minimum hitrate that scan can hit before scan
 
 option "sender-threads"         T "Threads used to send packets"
     typestr="n"
-    default="1"
+    default="min(4, number of cores on host)"
     optional int
 
 option "cores"                  - "Comma-separated list of cores to pin to"

--- a/src/ztee.1
+++ b/src/ztee.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZTEE" "1" "November 2023" "ZMap" "ztee"
+.TH "ZTEE" "1" "August 2021" "ZMap" "ztee"
 .
 .SH "NAME"
 \fBztee\fR \- output buffer and splitter

--- a/src/ztee.1.html
+++ b/src/ztee.1.html
@@ -120,7 +120,7 @@ in combination with <code>--raw</code>.</p></dd>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>November 2023</li>
+    <li class='tc'>August 2021</li>
     <li class='tr'>ztee(1)</li>
   </ol>
 


### PR DESCRIPTION
This should give us a more sane default, especially on hosts with less cores.

- [x] update manages
- [x] updated `--help`

# Testing

Ran on Mac, compiles and runs correctly

To test if it picks up cores correctly, ran on a Ubuntu VM with 2 cores, it detected this correctly.