### PR TITLE
Don't error in send_cleanup with empty batches (like with `--dryrun`)

### DIFF
--- a/src/send-bsd.h
+++ b/src/send-bsd.h
@@ -41,6 +41,10 @@ int send_packet(sock_t sock, void *buf, int len, UNUSED uint32_t idx)
 // Returns - number of packets sent
 // Returns -1 and sets errno if no packets could be sent successfully
 int send_batch(sock_t sock, batch_t* batch, int retries) {
+	if (batch->len == 0) {
+		// nothing to send
+		return EXIT_SUCCESS;
+	}
 	int packets_sent = 0;
 	int rc = 0;
 	for (int packet_num = 0; packet_num < batch->len; packet_num++) {
@@ -71,8 +75,6 @@ int send_batch(sock_t sock, batch_t* batch, int retries) {
 	if (packets_sent == 0) {
 		// simulating the return behaviour of the Linux send_mmsg sys call on error. Returns -1 and leaves
 		// errno as set by send_packet
-		log_error("send", "send_batch failed and no packets were able to be sent: "
-				  "%s", strerror(errno));
 		return -1;
 	}
 	return packets_sent;

--- a/src/send-linux.c
+++ b/src/send-linux.c
@@ -66,6 +66,10 @@ int send_run_init(sock_t s)
 }
 
 int send_batch(sock_t sock, batch_t* batch, int retries) {
+	if (batch->len == 0) {
+		// nothing to send
+		return EXIT_SUCCESS;
+	}
 	struct mmsghdr msgvec [batch->capacity]; // Array of multiple msg header structures
 	struct msghdr msgs[batch->capacity];
 	struct iovec iovs[batch->capacity];

--- a/src/send.c
+++ b/src/send.c
@@ -429,6 +429,7 @@ int send_run(sock_t st, shard_t *s)
 					int rc = send_batch(st, batch, attempts);
 					// whether batch succeeds or fails, this was the only attempt. Any re-tries are handled within batch
 					if (rc < 0) {
+						log_error("send_batch", "could not send any batch packets: %s", strerror(errno));
 						// rc is the last error code if all packets couldn't be sent
 						s->state.packets_failed += batch->len;
 					} else {

--- a/src/send.c
+++ b/src/send.c
@@ -471,7 +471,7 @@ int send_run(sock_t st, shard_t *s)
 	}
 cleanup:
 	if (!zconf.dryrun && send_batch(st, batch, attempts) < 0) {
-		log_error("send_batch cleanup", "could not clear out remaining batch packets: %s", strerror(errno));
+		log_error("send_batch cleanup", "could not send remaining batch packets: %s", strerror(errno));
 	}
 	free_packet_batch(batch);
 	s->cb(s->thread_id, s->arg);

--- a/src/send.c
+++ b/src/send.c
@@ -469,8 +469,8 @@ int send_run(sock_t st, shard_t *s)
 		}
 	}
 cleanup:
-	if (send_batch(st, batch, attempts) < 0) {
-		perror("error in cleanup, send_batch");
+	if (!zconf.dryrun && send_batch(st, batch, attempts) < 0) {
+		log_error("send_batch cleanup", "could not clear out remaining batch packets: %s", strerror(errno));
 	}
 	free_packet_batch(batch);
 	s->cb(s->thread_id, s->arg);


### PR DESCRIPTION
Fixes #765 , more details are available there.
Changes:

1. Don't error when `send_batch` is called with an empty batch
2. Don't call `send_batch` with `--dryrun` in `send_batch cleanup`

## Testing without `--dryrun`
```
$ sudo ./src/zmap  -p 80 --source-mac=74:a6:cd:d3:07:df -n 65 -c 1                      
Jan 21 15:02:01.655 [INFO] zmap: By default, ZMap will output the unique IP addresses of hosts that respond successfully (e.g., SYN-ACK packet). This is equivalent to running ZMap with the following flags: --output-module=csv --output-fields=saddr --output-filter='success=1 && repeat=0' --no-header-row. If you want all responses, explicitly set an output module or set --output-filter="".
Jan 21 15:02:01.655 [INFO] dedup: Response deduplication method is full
Jan 21 15:02:01.684 [INFO] recv: duplicate responses will be excluded from output
Jan 21 15:02:01.684 [INFO] recv: unsuccessful responses will be excluded from output
 0:00 0%; send: 3 1 p/s (3.24 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
209.87.59.95
25.234.63.152
20.219.200.226
 0:01 100%; send: 65 done (8.32 Kp/s avg); recv: 3 3 p/s (2 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 4.62%
Jan 21 15:02:03.694 [INFO] zmap: completed
```
## Testing with `--dryrun`
```
sudo ./src/zmap  -p 80 --source-mac=74:a6:cd:d3:07:df -n 2 -c 1 --dryrun

Jan 21 15:02:46.977 [INFO] zmap: By default, ZMap will output the unique IP addresses of hosts that respond successfully (e.g., SYN-ACK packet). This is equivalent to running ZMap with the following flags: --output-module=csv --output-fields=saddr --output-filter='success=1 && repeat=0' --no-header-row. If you want all responses, explicitly set an output module or set --output-filter="".
Jan 21 15:02:46.978 [INFO] dedup: Response deduplication method is full
Jan 21 15:02:47.004 [WARN] zmap: too few targets relative to senders, dropping to one sender
Jan 21 15:02:47.005 [INFO] send: dryrun mode -- won't actually send packets
tcp { source: 60311 | dest: 80 | seq: 3443441354 | checksum: 0X98EF }
ip { saddr: 192.168.116.160 | daddr: 142.87.195.165 | checksum: 0X6054 }
eth { shost: 74:a6:cd:d3:07:df | dhost: 06:28:38:19:36:12 }
------------------------------------------------------
tcp { source: 35134 | dest: 80 | seq: 2921426704 | checksum: 0XC8E }
ip { saddr: 192.168.116.160 | daddr: 91.65.84.78 | checksum: 0X2C2 }
eth { shost: 74:a6:cd:d3:07:df | dhost: 06:28:38:19:36:12 }
------------------------------------------------------
Jan 21 15:02:47.006 [INFO] zmap: completed

```
