### PR TITLE
Prevent --batch from overflowing the uint8_t it is being stored in

### DIFF
--- a/src/zmap.c
+++ b/src/zmap.c
@@ -901,10 +901,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (args.batch_given && args.batch_arg >= 1) {
+	if (args.batch_given && args.batch_arg >= 1 && args.batch_arg <= UINT8_MAX) {
 		zconf.batch = args.batch_arg;
 	} else if (args.batch_given) {
-		log_fatal("zmap", "batch size must be > 0");
+		log_fatal("zmap", "batch size must be > 0 and <= 255");
 	}
 
 	if (args.max_targets_given) {


### PR DESCRIPTION
Prevents crash for `--batch` sizes of multiples of 256, which stored in `zconf.batch` of type `uint8_t` end up as 0.

/cc @phillip-stephens 