### PR TITLE
Multiple fixes for BSD get_gateway code, remove libdnet

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,4 +97,3 @@ option. For example, to install it in `$HOME/opt` run
     make -j4
     make install
     ```
-- On some BSD systems, you man need to manually add `-D_SYSTYPE_BSD` to your CFLAGS.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,6 @@ ZMap has the following dependencies:
   - [libunistring](https://www.gnu.org/software/libunistring/) - Unicode string library
   - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) - compiler and library helper tool
   - [libjudy](https://judy.sourceforge.net/) - Judy Array for packet de-duplication
-  - [libdnet](https://github.com/dugsong/libdnet) - (macOS Only) Gateway and route detection
 
 Install the required dependencies with the following commands.
 
@@ -44,12 +43,12 @@ Install the required dependencies with the following commands.
 
 * On macOS systems (using [Homebrew](https://brew.sh/)):
   ```sh
-  brew install pkg-config cmake gmp gengetopt json-c byacc libdnet libunistring judy
+  brew install pkg-config cmake gmp gengetopt json-c byacc libunistring judy
   ```
 
 * On macOS systems (using [MacPorts](https://macports.org/)):
   ```
-  sudo port install cmake byacc flex gengetopt pkgconfig gmp libdnet libpcap json-c libunistring judy
+  sudo port install cmake byacc flex gengetopt pkgconfig gmp libpcap json-c libunistring judy
   ```
 
 * To launch a shell inside a Docker container with the build dependencies

--- a/lib/includes.h
+++ b/lib/includes.h
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef __APPLE__
-#pragma GCC diagnostic ignored "-Wflexible-array-extensions"
-#include <dnet.h>
-#pragma GCC diagnostic warning "-Wflexible-array-extensions"
-#endif
-
 #ifndef __FAVOR_BSD
 #define __FAVOR_BSD 2
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -210,11 +210,9 @@ add_executable(ztee ${ZTEESOURCES})
 add_executable(ztests ${ZTESTSOURCES})
 
 if(APPLE OR BSD)
-    set(DNET_LIBRARIES "dnet")
 else()
     set(ZTESTSOURCES ${ZTESTSOURCES} send-linux.c)
     set(SOURCES ${SOURCES} send-linux.c)
-    set(DNET_LIBRARIES "")
 endif()
 
 target_link_libraries(
@@ -222,7 +220,6 @@ target_link_libraries(
     zmaplib
     ${PFRING_LIBRARIES}
     pcap gmp m unistring
-    ${DNET_LIBRARIES}
     ${JSON_LIBRARIES}
 	${JUDY_LIBRARIES}
 )
@@ -251,7 +248,6 @@ target_link_libraries(
     zmaplib
     ${PFRING_LIBRARIES}
     pcap gmp m unistring
-    ${DNET_LIBRARIES}
     ${JSON_LIBRARIES}
 	${JUDY_LIBRARIES}
 )

--- a/src/get_gateway-bsd.h
+++ b/src/get_gateway-bsd.h
@@ -16,25 +16,15 @@
 #include <net/route.h>
 #include <net/if.h>
 #include <net/if_dl.h>
+#include <net/if_arp.h>
+#include <net/if_types.h>
+#include <netinet/if_ether.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <arpa/inet.h>
 #include <ifaddrs.h>
-
-#if defined(_SYSTYPE_BSD)
-
-#if __GNUC__ < 4
-#error "gcc version >= 4 is required"
-#elif __GNUC_MINOR_ >= 6
-#pragma GCC diagnostic ignored "-Wflexible-array-extensions"
-#endif
-
-#include <dnet/os.h>
-#include <dnet/eth.h>
-#include <dnet/ip.h>
-#include <dnet/ip6.h>
-#include <dnet/addr.h>
-#include <dnet/arp.h>
-#endif
+#include <assert.h>
 
 #define ROUNDUP(a) ((a) > 0 ? (1 + (((a)-1) | (sizeof(int) - 1))) : sizeof(int))
 #define UNUSED __attribute__((unused))
@@ -42,34 +32,49 @@
 int get_hw_addr(struct in_addr *gw_ip, UNUSED char *iface,
 		unsigned char *hw_mac)
 {
-	arp_t *arp;
-	struct arp_entry entry;
-
-	if (!gw_ip || !hw_mac) {
+	int mib[6];
+	mib[0] = CTL_NET;
+	mib[1] = PF_ROUTE;
+	mib[2] = 0;
+	mib[3] = AF_INET;
+	mib[4] = NET_RT_FLAGS;
+	mib[5] = RTF_LLINFO;
+	size_t bufsz = 0;
+	if (sysctl(mib, 6, NULL, &bufsz, NULL, 0) == -1) {
+		log_debug("get_hw_addr", "sysctl getting buffer size: %d %s", errno, strerror(errno));
+		return EXIT_FAILURE;
+	}
+	uint8_t *buf = (uint8_t *)malloc(bufsz);
+	assert(buf);
+	if (sysctl(mib, 6, buf, &bufsz, NULL, 0) == -1) {
+		log_debug("get_hw_addr", "sysctl getting buffer data: %d %s", errno, strerror(errno));
 		return EXIT_FAILURE;
 	}
 
-	if ((arp = arp_open()) == NULL) {
-		log_error("get_hw_addr", "failed to open arp table");
-		return EXIT_FAILURE;
+	int result = EXIT_FAILURE;
+	uint8_t *bufend = buf + bufsz;
+	size_t min_msglen = sizeof(struct rt_msghdr) + sizeof(struct sockaddr_inarp) + sizeof(struct sockaddr_dl);
+	struct rt_msghdr *rtm = (struct rt_msghdr *)buf;
+	for (uint8_t *p = buf; p < bufend; p += rtm->rtm_msglen) {
+		rtm = (struct rt_msghdr *)p;
+		if ((p + sizeof(struct rt_msghdr) >= bufend) ||
+		    (p + rtm->rtm_msglen >= bufend) ||
+		    (rtm->rtm_msglen < min_msglen)) {
+			break;
+		}
+		struct sockaddr_inarp *sin = (struct sockaddr_inarp *)(rtm + 1);
+		struct sockaddr_dl *sdl = (struct sockaddr_dl *)(sin + 1);
+		assert(sin->sin_family == AF_INET);
+		if (sin->sin_addr.s_addr != gw_ip->s_addr) {
+			continue;
+		}
+		assert(sdl->sdl_family == AF_LINK);
+		memcpy(hw_mac, LLADDR(sdl), ETHER_ADDR_LEN);
+		result = EXIT_SUCCESS;
 	}
 
-	// Convert gateway ip to dnet struct format
-	memset(&entry, 0, sizeof(struct arp_entry));
-	entry.arp_pa.addr_type = ADDR_TYPE_IP;
-	entry.arp_pa.addr_bits = IP_ADDR_BITS;
-	entry.arp_pa.addr_ip = gw_ip->s_addr;
-
-	if (arp_get(arp, &entry) < 0) {
-		log_debug("get_hw_addr", "failed to fetch arp entry");
-		return EXIT_FAILURE;
-	} else {
-		log_debug("get_hw_addr", "found ip %s at hw_addr %s",
-			  addr_ntoa(&entry.arp_pa), addr_ntoa(&entry.arp_ha));
-		memcpy(hw_mac, &entry.arp_ha.addr_eth, ETHER_ADDR_LEN);
-	}
-	arp_close(arp);
-	return EXIT_SUCCESS;
+	free(buf);
+	return result;
 }
 
 int get_iface_ip(char *iface, struct in_addr *ip)

--- a/src/get_gateway-bsd.h
+++ b/src/get_gateway-bsd.h
@@ -100,6 +100,7 @@ int get_iface_ip(char *iface, struct in_addr *ip)
 			ip->s_addr = sin->sin_addr.s_addr;
 			log_debug("get-iface-ip", "IP address found for %s: %s",
 				  iface, inet_ntoa(*ip));
+			freeifaddrs(ifaddr);
 			return EXIT_SUCCESS;
 		}
 	}
@@ -158,11 +159,13 @@ int _get_default_gw(struct in_addr *gw, char **iface)
 	while (rtm->rtm_type == RTM_GET &&
 	       (len = read(fd, rtm, sizeof(buf))) > 0) {
 		if (len < (int)sizeof(*rtm)) {
+			close(fd);
 			return (-1);
 		}
 		if (rtm->rtm_type == RTM_GET && rtm->rtm_pid == getpid() &&
 		    rtm->rtm_seq == seq) {
 			if (rtm->rtm_errno) {
+				close(fd);
 				errno = rtm->rtm_errno;
 				return (-1);
 			}


### PR DESCRIPTION
Fixes and modernisations for BSD `get_gateway` code:

- Fix `get_iface_hw_addr()` on macOS, where `--source-mac` was needed in at least some cases, depending on libdnet, by rewriting it using getifaddrs(3) in lieu of libdnet.  getifaddrs(3) is generally portable across all BSD variants and it had already been used for `get_iface_ip`.
- Fix `get_hw_addr()` on FreeBSD, where `--gateway-mac` was needed, by rewriting it using `sysctl(2)` in lieu of libdnet.
- While here, fix two file descriptor leaks and one memory leak in `get_default_iface` and `get_default_gw`.
- Remove the libdnet dependency; it had already been removed for Linux, now it is no longer needed for macOS / BSD either.

Tested on macOS Sonoma as well as FreeBSD 14.0.

(Apologies for extending the scope of an already open PR, but it seemed to make more sense to reason about these changes as a whole, not separately.  Happy to split into multiple PRs if you prefer.)