### PR TITLE
Stop defining the now defunct _SYSTYPE_BSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 if("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD" OR "${CMAKE_SYSTEM_NAME}" MATCHES "NetBSD" OR "${CMAKE_SYSTEM_NAME}" MATCHES "DragonFly")
     set(BSD "YES")
-    add_definitions("-D_SYSTYPE_BSD")
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" MATCHES "NetBSD")


### PR DESCRIPTION
This leftover bit was the result of a collision of two in-flight PRs. The last use of `_SYSTYPE_BSD` was removed along with libdnet in #772, while #771 at the same time added the `-D_SYSTYPE_BSD` to `CMakeLists.txt` in order to remove the need to manually define it when building.

`_SYSTYPE_BSD` is a rather archaic define.  libdnet might have used it for compat with now historical systems/compilers, but I do not think it served any purpose beyond that.  Certainly, modern FreeBSD, NetBSD and macOS do not reference it at all.  It seems safe to remove.