### PR TITLE
Support IP layer mode on macOS

### DIFF
--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -69,6 +69,11 @@ void recv_init(void)
 			  errbuf);
 	}
 	switch (pcap_datalink(pc)) {
+	case DLT_NULL:
+		// utun on macOS
+		log_debug("recv", "BSD loopback encapsulation");
+		zconf.data_link_size = 4;
+		break;
 	case DLT_EN10MB:
 		log_debug("recv", "Data link layer Ethernet");
 		zconf.data_link_size = sizeof(struct ether_header);
@@ -84,7 +89,7 @@ void recv_init(void)
 		break;
 #endif
 	default:
-		log_error("recv", "unknown data link layer");
+		log_error("recv", "unknown data link layer: %u", pcap_datalink(pc));
 	}
 
 	struct bpf_program bpf;

--- a/src/send-mac.h
+++ b/src/send-mac.h
@@ -39,7 +39,7 @@ int send_packet(sock_t sock, void *buf, int len, UNUSED uint32_t retry_ct)
 		struct ip *iph = (struct ip *)buf;
 #ifdef __APPLE__
 		// The len and off fields need to be in host byte order on macOS.
-		if (retry_ct > 0) {
+		if (retry_ct == 0) {
 			iph->ip_len = ntohs(iph->ip_len);
 			iph->ip_off = ntohs(iph->ip_off);
 			iph->ip_sum = 0;

--- a/src/socket-bsd.c
+++ b/src/socket-bsd.c
@@ -17,50 +17,72 @@
 #include <sys/time.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <net/bpf.h>
 
 #include "state.h"
 
 sock_t get_socket(UNUSED uint32_t id)
 {
-	char file[32];
-	int bpf;
-	// Assume failure
-	sock_t ret;
-	ret.sock = -1;
+	sock_t sock;
+	sock.sock = -1;
 
+#ifndef __APPLE__
 	if (zconf.send_ip_pkts && !zconf.dryrun) {
-		log_fatal("socket", "iplayer not supported on bsd");
+		log_fatal("socket", "iplayer not supported on BSD other than macOS");
 	}
+#endif
 
-	// Try to find a valid bpf
-	for (int i = 0; i < 128; i++) {
-		snprintf(file, sizeof(file), "/dev/bpf%d", i);
-		bpf = open(file, O_WRONLY);
-		if (bpf != -1 || errno != EBUSY)
-			break;
+	if (zconf.send_ip_pkts) {
+		int fd = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
+		if (fd == -1) {
+			log_debug("socket-bsd", "socket(PF_INET, SOCK_RAW, IPPROTO_IP) failed: %d %s", errno, strerror(errno));
+			return sock;
+		}
+
+		int yes = 1;
+		if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &yes, sizeof(yes)) == -1) {
+			log_debug("socket-bsd", "setsockopt(IP_HDRINCL) failed: %d %s", errno, strerror(errno));
+			return sock;
+		}
+
+		sock.sock = fd;
+	} else {
+		int bpf;
+		char file[32];
+
+		// Try to find a valid bpf
+		for (int i = 0; i < 128; i++) {
+			snprintf(file, sizeof(file), "/dev/bpf%d", i);
+			bpf = open(file, O_WRONLY);
+			if (bpf != -1 || errno != EBUSY)
+				break;
+		}
+
+		// Make sure it worked
+		if (bpf < 0) {
+			return sock;
+		}
+
+		// Set up an ifreq to bind to
+		struct ifreq ifr;
+		memset(&ifr, 0, sizeof(ifr));
+		strlcpy(ifr.ifr_name, zconf.iface, sizeof(ifr.ifr_name));
+
+		// Bind the bpf to the interface
+		if (ioctl(bpf, BIOCSETIF, (char *)&ifr) < 0) {
+			close(bpf);
+			return sock;
+		}
+
+		// Enable writing the address in
+		int write_addr_enable = 1;
+		if (ioctl(bpf, BIOCSHDRCMPLT, &write_addr_enable) < 0) {
+			close(bpf);
+			return sock;
+		}
+
+		sock.sock = bpf;
 	}
-
-	// Make sure it worked
-	if (bpf < 0) {
-		return ret;
-	}
-
-	// Set up an ifreq to bind to
-	struct ifreq ifr;
-	memset(&ifr, 0, sizeof(ifr));
-	strlcpy(ifr.ifr_name, zconf.iface, sizeof(ifr.ifr_name));
-
-	// Bind the bpf to the interface
-	if (ioctl(bpf, BIOCSETIF, (char *)&ifr) < 0) {
-		return ret;
-	}
-
-	// Enable writing the address in
-	int write_addr_enable = 1;
-	if (ioctl(bpf, BIOCSHDRCMPLT, &write_addr_enable) < 0) {
-		return ret;
-	}
-	ret.sock = bpf;
-	return ret;
+	return sock;
 }


### PR DESCRIPTION
- Implement IP layer mode on macOS using `socket(PF_INET, SOCK_RAW, IPPROTO_RAW)` and `setsockopt(IP_HDRINCL)`
- Teach recv-pcap to handle BSD loopback encapsulation as used by macOS `utun` interfaces
- While here fix file descriptor leaks in bpf failure paths

Deliberately ifdef'ed macOS-specific code with `__APPLE__` such that in the future, the code can be shared amongst macOS and BSDs lacking sendmmsg.  If/when I get around to implement sendmmsg for BSD, I'll likely propose to split send code into bsd-legacy and bsd-sendmmsg, instead of send-bsd and send-mac with largely duplicate code for the "no sendmmsg available" case.