### PR TITLE
Fix benign compiler warnings on macOS/FreeBSD clang

### DIFF
--- a/lib/cachehash.c
+++ b/lib/cachehash.c
@@ -149,7 +149,7 @@ void *cachehash_has(cachehash *ch, const void *key, size_t keylen)
 	assert(ch);
 	assert(key);
 	assert(keylen);
-	node_t *n = judy_get(ch, key, keylen);
+	node_t *n = judy_get(ch, (void *)key, keylen);
 	if (n) {
 		return n->data;
 	} else {
@@ -163,7 +163,7 @@ void *cachehash_get(cachehash *ch, const void *key, size_t keylen)
 	assert(key);
 	assert(keylen);
 
-	node_t *n = judy_get(ch, key, keylen);
+	node_t *n = judy_get(ch, (void *)key, keylen);
 	if (n) {
 		use(ch, n);
 		return n->data;
@@ -214,7 +214,7 @@ void cachehash_put(cachehash *ch, const void *key, size_t keylen, void *value)
 	ch->currsize++;
 	// add to judy array
 	Word_t *v_;
-	JHSI(v_, ch->judy, key, keylen);
+	JHSI(v_, ch->judy, (void *)key, keylen);
 	// key should not already be in hash table
 	assert(!*v_);
 	*v_ = (Word_t)n;

--- a/src/parser.y
+++ b/src/parser.y
@@ -10,7 +10,7 @@ void yyerror(const char *str)
 	fprintf(stderr,"Parse error: %s\n",str);
 }
  
-int yywrap()
+int yywrap(void)
 {
 	return 1;
 }

--- a/src/recv.c
+++ b/src/recv.c
@@ -101,7 +101,7 @@ void handle_packet(uint32_t buflen, const u_char *bytes,
 	// have ETH_P_IP proto and 00s for dest/src).
 	if (zconf.send_ip_pkts) {
 		const static uint32_t available_space = sizeof(fake_eth_hdr) - sizeof(struct ether_header);
-		assert(buflen > zconf.data_link_size);
+		assert(buflen > (uint32_t)zconf.data_link_size);
 		buflen -= zconf.data_link_size;
 		if (buflen > available_space) {
 			buflen = available_space;

--- a/src/send.c
+++ b/src/send.c
@@ -417,7 +417,7 @@ int send_run(sock_t st, shard_t *s)
 				// this is an additional memcpy (packet created in buf, buf -> batch)
 				// but when I modified the TCP SYN module to write packet to batch directly, there wasn't any noticeable speedup.
 				// Using this approach for readability/minimal changes
-				memcpy(((void *)batch->packets) + (batch->len * MAX_PACKET_SIZE), contents, length);
+				memcpy(((uint8_t *)batch->packets) + (batch->len * MAX_PACKET_SIZE), contents, length);
 				batch->lens[batch->len] = length;
 				batch->ips[batch->len] = current_ip;
 				batch->len++;


### PR DESCRIPTION
Fix benign compiler warnings on macOS/FreeBSD clang:

```
lib/cachehash.c:152:27: warning: passing 'const void *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        node_t *n = judy_get(ch, key, keylen);
                                 ^~~
```

```
lib/cachehash.c:166:27: warning: passing 'const void *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        node_t *n = judy_get(ch, key, keylen);
                                 ^~~
```

```
lib/cachehash.c:217:21: warning: passing 'const void *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
        JHSI(v_, ch->judy, key, keylen);
                           ^~~
```

```
src/recv.c:104:17: warning: comparison of integers of different signs: 'uint32_t' (aka 'unsigned int') and 'int' [-Wsign-compare]
                assert(buflen > zconf.data_link_size);
                       ~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~
```

```
src/send.c:420:37: warning: arithmetic on a pointer to void is a GNU extension [-Wgnu-pointer-arith]
                                memcpy(((void *)batch->packets) + (batch->len * MAX_PACKET_SIZE), contents, length);
                                       ~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

```
src/parser.y:13:11: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
int yywrap()
          ^
           void
```