### PR TITLE
phillip/781: elevate debug log if can't get a socket on bsd to fatal

### DIFF
--- a/src/socket-bsd.c
+++ b/src/socket-bsd.c
@@ -36,8 +36,8 @@ sock_t get_socket(UNUSED uint32_t id)
 	if (zconf.send_ip_pkts) {
 		int fd = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
 		if (fd == -1) {
-			log_debug("socket-bsd", "socket(PF_INET, SOCK_RAW, IPPROTO_IP) failed: %d %s", errno, strerror(errno));
-			return sock;
+			log_fatal("socket-bsd", "obtaining socket(PF_INET, SOCK_RAW, IPPROTO_IP) failed: %d %s. You likely do not have privileges to open a raw packet socket. " \
+						    "Are you running as root or with the CAP_NET_RAW capability?", errno, strerror(errno));
 		}
 
 		int yes = 1;

--- a/src/socket-bsd.c
+++ b/src/socket-bsd.c
@@ -37,13 +37,13 @@ sock_t get_socket(UNUSED uint32_t id)
 		int fd = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
 		if (fd == -1) {
 			log_fatal("socket-bsd", "obtaining socket(PF_INET, SOCK_RAW, IPPROTO_IP) failed: %d %s. You likely do not have privileges to open a raw packet socket. " \
-						    "Are you running as root or with the CAP_NET_RAW capability?", errno, strerror(errno));
+						    "Are you running as root?", errno, strerror(errno));
 		}
 
 		int yes = 1;
 		if (setsockopt(fd, IPPROTO_IP, IP_HDRINCL, &yes, sizeof(yes)) == -1) {
-			log_debug("socket-bsd", "setsockopt(IP_HDRINCL) failed: %d %s", errno, strerror(errno));
-			return sock;
+			// could not inform the kernel that ZMap will be filling out the IP header and the kernel does not need to
+			log_fatal("socket-bsd", "setsockopt(IP_HDRINCL) failed: %d %s", errno, strerror(errno));
 		}
 
 		sock.sock = fd;
@@ -61,7 +61,7 @@ sock_t get_socket(UNUSED uint32_t id)
 
 		// Make sure it worked
 		if (bpf < 0) {
-			return sock;
+			log_fatal("socket-bsd", "could not get an open packet filter");
 		}
 
 		// Set up an ifreq to bind to
@@ -72,14 +72,14 @@ sock_t get_socket(UNUSED uint32_t id)
 		// Bind the bpf to the interface
 		if (ioctl(bpf, BIOCSETIF, (char *)&ifr) < 0) {
 			close(bpf);
-			return sock;
+			log_fatal("socket-bsd", "could not bind the packet filter to the interface %s", ifr.ifr_name);
 		}
 
-		// Enable writing the address in
+		// Inform the interface that the source address will be filled out by ZMap and the kernel doens't need to write it
 		int write_addr_enable = 1;
 		if (ioctl(bpf, BIOCSHDRCMPLT, &write_addr_enable) < 0) {
 			close(bpf);
-			return sock;
+			log_fatal("socket-bsd", "could not set the status of the header complete flag to the packet filter on interface %s", ifr.ifr_name);
 		}
 
 		sock.sock = bpf;


### PR DESCRIPTION
Noticed in testing this [PR](https://github.com/zmap/zmap/pull/778) that if the user forgets `sudo`, there were a bunch of errors printed on Mac. @droe had the exact same setup but wasn't seeing this behavior, which is odd. Either way, I think this fix makes sense. If you can't get a socket, you can't send packets, so this should be a fatal error, IMO.