### PR TITLE
Avoid isomorphism 0

### DIFF
--- a/src/cyclic.c
+++ b/src/cyclic.c
@@ -135,6 +135,10 @@ static uint32_t find_primroot(const cyclic_group_t *group, aesrand_t *aes)
 		candidate %= group->prime;
 		candidate %= max_root;
 
+		if (candidate == 0) {
+			continue;
+		}
+
 		mpz_t prime;
 		mpz_init_set_ui(prime, group->prime);
 		int ok = 1;


### PR DESCRIPTION
With probability of roughly 1/group->prime, find_primroot() was allowing a candidate value of 0 through the checks, resulting in a scan that only sent one packet per send thread, all to index 0, because `shard->params.factor` ended up as 0.