### PR TITLE
Fix assertion failure when shard_roll_to_valid() iterates to the end

### DIFF
--- a/src/shard.c
+++ b/src/shard.c
@@ -142,6 +142,11 @@ void shard_init(shard_t *shard, uint16_t shard_idx, uint16_t num_shards,
 
 target_t shard_get_cur_target(shard_t *shard)
 {
+	if (shard->current == ZMAP_SHARD_DONE) {
+		// shard_roll_to_valid() has rolled to the very end.
+		return (target_t){
+		    .ip = 0, .port = 0, .status = ZMAP_SHARD_DONE};
+	}
 	uint32_t ip = extract_ip(shard->current - 1, shard->bits_for_port);
 	uint16_t port = extract_port(shard->current - 1, shard->bits_for_port);
 	return (target_t){.ip = (uint32_t)blocklist_lookup_index(ip),


### PR DESCRIPTION
Prevents shard->current from wrapping around from 0 (`ZMAP_SHARD_DONE`) to -1 and causing an assertion failure in the constraint lookup code:

```
Assertion failed: (index < con->root->count), function constraint_lookup_index, file constraint.c, line 253.
```

This situation only manifested if one of the send threads happened to get a range containing no usable elements, which is extremely unlikely in normal ZMap use cases, but occurred relatively frequently when scanning only very few targets, such as a /29, using multiple send threads, i.e. #threads ≈ #targets.