### PR TITLE
Fixed bug in the shard initialization w/ multi-port

### DIFF
--- a/src/shard.c
+++ b/src/shard.c
@@ -31,7 +31,7 @@ static inline uint32_t extract_ip(uint64_t v, uint8_t bits)
 static void shard_roll_to_valid(shard_t *s)
 {
 	uint64_t current_ip_index = (s->current - 1) >> s->bits_for_port;
-    uint16_t candidate_port = extract_port(s->current - 1, s->bits_for_port);
+	uint16_t candidate_port = extract_port(s->current - 1, s->bits_for_port);
 	if (current_ip_index < zsend.max_index && candidate_port < zconf.ports->port_count) {
 		return;
 	}

--- a/src/shard.c
+++ b/src/shard.c
@@ -31,7 +31,8 @@ static inline uint32_t extract_ip(uint64_t v, uint8_t bits)
 static void shard_roll_to_valid(shard_t *s)
 {
 	uint64_t current_ip_index = (s->current - 1) >> s->bits_for_port;
-	if (current_ip_index < zsend.max_index) {
+    uint16_t candidate_port = extract_port(s->current - 1, s->bits_for_port);
+	if (current_ip_index < zsend.max_index && candidate_port < zconf.ports->port_count) {
 		return;
 	}
 	shard_get_next_target(s);


### PR DESCRIPTION
While working on the integration test PR, I noticed my tests around multiple ports were intermittently failing. After some investigation, I believe this is the fix. This just adds the check already present in `shard_get_next_target` [here](https://github.com/zmap/zmap/blob/main/src/shard.c#L185) to the `shard_roll_to_valid`.

My tests pass after this fix.