### PR TITLE
netmap: Add --netmap-wait-ping to work around STP blocking ports temporarily

### DIFF
--- a/README.netmap.md
+++ b/README.netmap.md
@@ -47,6 +47,18 @@ access, you will lose connectivity until ZMap exits.
 $ sudo ./src/zmap -p 443 -i ix0 -o output.csv
 ```
 
+Going into and leaving Netmap mode causes the link to go down and up as part of
+a PHY reset.  If the interface is connected to a switch with STP enabled, then
+depending on port configuration, the switch might be muting the port for as
+many as 30 seconds while the port goes through the listening and learning STP
+states.  To work around this, use `--netmap-wait-ping` with an address that you
+know will respond to ICMP echo requests.  ZMap will then only start scanning
+after having received an ICMP echo reply from the address.
+
+```
+$ sudo ./src/zmap -p 443 -i ix0 -o output.csv --netmap-wait-ping 8.8.8.8
+```
+
 
 ### Considerations
 

--- a/src/state.h
+++ b/src/state.h
@@ -150,6 +150,7 @@ struct state_conf {
 		int nm_fd;
 		void *nm_mem;
 		struct netmap_if *nm_if;
+		uint32_t wait_ping_dstip;
 	} nm;
 #endif
 };

--- a/src/utility.h
+++ b/src/utility.h
@@ -17,6 +17,9 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
+#include <netinet/in.h>
+
 void parse_source_ip_addresses(char given_string[]);
+in_addr_t string_to_ip_address(char *t);
 
 #endif // UTILITY_H

--- a/src/zblocklist.1
+++ b/src/zblocklist.1
@@ -1,59 +1,42 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
 .TH "ZBLOCKLIST" "1" "February 2024" "ZMap" "zblocklist"
-.
 .SH "NAME"
 \fBzblocklist\fR \- zmap IP blocklist tool
-.
 .SH "SYNOPSIS"
-zblocklist [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
-.
+zblocklist [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\|\.\|\.\|\. ]
 .SH "DESCRIPTION"
 \fIZBlacklist\fR is a network tool for limiting and deduplicating a list of IP addresses using a blocklist or allowlist\.
-.
 .SH "OPTIONS"
-.
 .SS "BASIC OPTIONS"
-.
 .TP
 \fB\-b\fR, \fB\-\-blocklist\-file=path\fR
 File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblocklist\.conf\fR for this purpose\.
-.
 .TP
 \fB\-w\fR, \fB\-\-allowlist\-file=name\fR
 File of subnets to include, in CIDR notation, one\-per line\. All other subnets will be excluded\.
-.
 .TP
 \fB\-l\fR, \fB\-\-log\-file=name\fR
 File to log to\.
-.
 .TP
 \fB\-\-disable\-syslog\fR
 Disable logging messages to syslog\.
-.
 .TP
 \fB\-v\fR, \fB\-\-verbosity\fR
 Level of log detail (0\-5, default=3)
-.
 .TP
 \fB\-\-no\-duplicate\-checking\fR
 Don\'t deduplicate input addresses\. Default is false\.
-.
 .TP
 \fB\-\-ignore\-blocklist\-errors\fR
 Ignore invalid, malformed, or unresolvable entries in the blocklist/allowlist\. Default is false\.
-.
 .TP
 \fB\-\-ignore\-input\-errors\fR
 Don\'t print invalid entries in the input\. Default is false\.
-.
 .SS "ADDITIONAL OPTIONS"
-.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help and exit
-.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version and exit

--- a/src/zblocklist.1.html
+++ b/src/zblocklist.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>zblocklist(1) - zmap IP blocklist tool</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -65,11 +65,12 @@
     <li class='tr'>zblocklist(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>zblocklist</code> - <span class="man-whatis">zmap IP blocklist tool</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p>zblocklist [ -b &lt;blocklist&gt; ] [ -w &lt;allowlist&gt; ] [ OPTIONS... ]</p>
@@ -84,30 +85,49 @@ IP addresses using a blocklist or allowlist.</p>
 <h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
 
 <dl>
-<dt> <code>-b</code>, <code>--blocklist-file=path</code></dt><dd><p> File of subnets to exclude, in CIDR notation, one-per line. It is
- recommended you use this to exclude RFC 1918 addresses, multicast, IANA
- reserved space, and other IANA special-purpose addresses. An example
- blocklist file <strong>blocklist.conf</strong> for this purpose.</p></dd>
-<dt><code>-w</code>, <code>--allowlist-file=name</code></dt><dd><p>File of subnets to include, in CIDR notation, one-per line. All other
-subnets will be excluded.</p></dd>
-<dt><code>-l</code>, <code>--log-file=name</code></dt><dd><p>File to log to.</p></dd>
-<dt><code>--disable-syslog</code></dt><dd><p>Disable logging messages to syslog.</p></dd>
-<dt><code>-v</code>, <code>--verbosity</code></dt><dd><p>Level of log detail (0-5, default=3)</p></dd>
-<dt><code>--no-duplicate-checking</code></dt><dd><p>Don't deduplicate input addresses. Default is false.</p></dd>
-<dt><code>--ignore-blocklist-errors</code></dt><dd><p>Ignore invalid, malformed, or unresolvable entries in the
-blocklist/allowlist. Default is false.</p></dd>
-<dt><code>--ignore-input-errors</code></dt><dd><p>Don't print invalid entries in the input. Default is false.</p></dd>
+<dt>
+<code>-b</code>, <code>--blocklist-file=path</code>
+</dt>
+<dd>File of subnets to exclude, in CIDR notation, one-per line. It is
+recommended you use this to exclude RFC 1918 addresses, multicast, IANA
+reserved space, and other IANA special-purpose addresses. An example
+blocklist file <strong>blocklist.conf</strong> for this purpose.</dd>
+<dt>
+<code>-w</code>, <code>--allowlist-file=name</code>
+</dt>
+<dd>File of subnets to include, in CIDR notation, one-per line. All other
+subnets will be excluded.</dd>
+<dt>
+<code>-l</code>, <code>--log-file=name</code>
+</dt>
+<dd>File to log to.</dd>
+<dt><code>--disable-syslog</code></dt>
+<dd>Disable logging messages to syslog.</dd>
+<dt>
+<code>-v</code>, <code>--verbosity</code>
+</dt>
+<dd>Level of log detail (0-5, default=3)</dd>
+<dt><code>--no-duplicate-checking</code></dt>
+<dd>Don't deduplicate input addresses. Default is false.</dd>
+<dt><code>--ignore-blocklist-errors</code></dt>
+<dd>Ignore invalid, malformed, or unresolvable entries in the
+blocklist/allowlist. Default is false.</dd>
+<dt><code>--ignore-input-errors</code></dt>
+<dd>Don't print invalid entries in the input. Default is false.</dd>
 </dl>
-
 
 <h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
 
 <dl>
-<dt><code>-h</code>, <code>--help</code></dt><dd><p>Print help and exit</p></dd>
-<dt><code>-V</code>, <code>--version</code></dt><dd><p>Print version and exit</p></dd>
+<dt>
+<code>-h</code>, <code>--help</code>
+</dt>
+<dd>Print help and exit</dd>
+<dt>
+<code>-V</code>, <code>--version</code>
+</dt>
+<dd>Print version and exit</dd>
 </dl>
-
-
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>

--- a/src/ziterate.1
+++ b/src/ziterate.1
@@ -1,73 +1,52 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
 .TH "ZITERATE" "1" "February 2024" "ZMap" "ziterate"
-.
 .SH "NAME"
 \fBziterate\fR \- ZMap IP permutation generation file
-.
 .SH "SYNOPSIS"
-ziterate [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\.\.\. ]
-.
+ziterate [ \-b <blocklist> ] [ \-w <allowlist> ] [ OPTIONS\|\.\|\.\|\. ]
 .SH "DESCRIPTION"
 \fIZIterate\fR is a network tool that will produce IPv4 addresses in a psuedorandom order similar to how ZMap generates random addresses to be scanned\.
-.
 .SH "OPTIONS"
-.
 .SS "BASIC OPTIONS"
-.
 .TP
 \fB\-p\fR, \fB\-\-target\-ports=port(s)\fR
 List of TCP/UDP ports and/or port ranges to scan\. (e\.g\., 80,443,100\-105)\. Use \'*\' to scan all ports, including port 0\. If no port is specified, ziterate will output only IPs\.
-.
 .TP
 \fB\-b\fR, \fB\-\-blocklist\-file=path\fR
 File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblocklist\.conf\fR for this purpose\.
-.
 .TP
 \fB\-w\fR, \fB\-\-allowlist\-file=name\fR
 File of subnets to include, in CIDR notation, one\-per line\. All other subnets will be excluded\.
-.
 .TP
 \fB\-l\fR, \fB\-\-log\-file=name\fR
 File to log to\.
-.
 .TP
 \fB\-\-disable\-syslog\fR
 Disable logging messages to syslog\.
-.
 .TP
 \fB\-v\fR, \fB\-\-verbosity\fR
 Level of log detail (0\-5, default=3)
-.
 .TP
 \fB\-\-ignore\-blocklist\-errors\fR
 Ignore invalid entries in the blocklist\. Default is false\.
-.
 .TP
 \fB\-\-seed=n\fR
 Seed used to select address permutation\.
-.
 .TP
 \fB\-n\fR, \fB\-\-max\-targets=n\fR
 Cap number of IPs to generate (as a number or a percentage of the address space)
-.
 .SS "SHARDING"
-.
 .TP
 \fB\-\-shards=n\fR
 Total number of shards\.
-.
 .TP
 \fB\-\-shard=n\fR
 Shard this scan is targeting\. Zero indexed\.
-.
 .SS "ADDITIONAL OPTIONS"
-.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help text and exit\.
-.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version and exit\.

--- a/src/ziterate.1.html
+++ b/src/ziterate.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>ziterate(1) - ZMap IP permutation generation file</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -65,11 +65,12 @@
     <li class='tr'>ziterate(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>ziterate</code> - <span class="man-whatis">ZMap IP permutation generation file</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p>ziterate [ -b &lt;blocklist&gt; ] [ -w &lt;allowlist&gt; ] [ OPTIONS... ]</p>
@@ -84,40 +85,65 @@ order similar to how ZMap generates random addresses to be scanned.</p>
 <h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
 
 <dl>
-<dt> <code>-p</code>, <code>--target-ports=port(s)</code></dt><dd><p> List of TCP/UDP ports and/or port ranges to scan. (e.g., 80,443,100-105).
- Use '*' to scan all ports, including port 0. If no port is specified,
- ziterate will output only IPs.</p></dd>
-<dt> <code>-b</code>, <code>--blocklist-file=path</code></dt><dd><p> File of subnets to exclude, in CIDR notation, one-per line. It is
- recommended you use this to exclude RFC 1918 addresses, multicast, IANA
- reserved space, and other IANA special-purpose addresses. An example
- blocklist file <strong>blocklist.conf</strong> for this purpose.</p></dd>
-<dt><code>-w</code>, <code>--allowlist-file=name</code></dt><dd><p>File of subnets to include, in CIDR notation, one-per line. All other
-subnets will be excluded.</p></dd>
-<dt><code>-l</code>, <code>--log-file=name</code></dt><dd><p>File to log to.</p></dd>
-<dt><code>--disable-syslog</code></dt><dd><p>Disable logging messages to syslog.</p></dd>
-<dt><code>-v</code>, <code>--verbosity</code></dt><dd><p>Level of log detail (0-5, default=3)</p></dd>
-<dt><code>--ignore-blocklist-errors</code></dt><dd><p>Ignore invalid entries in the blocklist. Default is false.</p></dd>
-<dt><code>--seed=n</code></dt><dd><p>Seed used to select address permutation.</p></dd>
-<dt><code>-n</code>, <code>--max-targets=n</code></dt><dd><p>Cap number of IPs to generate (as a number or a percentage of the address space)</p></dd>
+<dt>
+<code>-p</code>, <code>--target-ports=port(s)</code>
+</dt>
+<dd>List of TCP/UDP ports and/or port ranges to scan. (e.g., 80,443,100-105).
+Use '*' to scan all ports, including port 0. If no port is specified,
+ziterate will output only IPs.</dd>
+<dt>
+<code>-b</code>, <code>--blocklist-file=path</code>
+</dt>
+<dd>File of subnets to exclude, in CIDR notation, one-per line. It is
+recommended you use this to exclude RFC 1918 addresses, multicast, IANA
+reserved space, and other IANA special-purpose addresses. An example
+blocklist file <strong>blocklist.conf</strong> for this purpose.</dd>
+<dt>
+<code>-w</code>, <code>--allowlist-file=name</code>
+</dt>
+<dd>File of subnets to include, in CIDR notation, one-per line. All other
+subnets will be excluded.</dd>
+<dt>
+<code>-l</code>, <code>--log-file=name</code>
+</dt>
+<dd>File to log to.</dd>
+<dt><code>--disable-syslog</code></dt>
+<dd>Disable logging messages to syslog.</dd>
+<dt>
+<code>-v</code>, <code>--verbosity</code>
+</dt>
+<dd>Level of log detail (0-5, default=3)</dd>
+<dt><code>--ignore-blocklist-errors</code></dt>
+<dd>Ignore invalid entries in the blocklist. Default is false.</dd>
+<dt><code>--seed=n</code></dt>
+<dd>Seed used to select address permutation.</dd>
+<dt>
+<code>-n</code>, <code>--max-targets=n</code>
+</dt>
+<dd>Cap number of IPs to generate (as a number or a percentage of the address space)</dd>
 </dl>
-
 
 <h3 id="SHARDING">SHARDING</h3>
 
 <dl>
-<dt><code>--shards=n</code></dt><dd><p>Total number of shards.</p></dd>
-<dt><code>--shard=n</code></dt><dd><p>Shard this scan is targeting. Zero indexed.</p></dd>
+<dt><code>--shards=n</code></dt>
+<dd>Total number of shards.</dd>
+<dt><code>--shard=n</code></dt>
+<dd>Shard this scan is targeting. Zero indexed.</dd>
 </dl>
-
 
 <h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
 
 <dl>
-<dt><code>-h</code>, <code>--help</code></dt><dd><p>Print help text and exit.</p></dd>
-<dt><code>-V</code>, <code>--version</code></dt><dd><p>Print version and exit.</p></dd>
+<dt>
+<code>-h</code>, <code>--help</code>
+</dt>
+<dd>Print help text and exit.</dd>
+<dt>
+<code>-V</code>, <code>--version</code>
+</dt>
+<dd>Print version and exit.</dd>
 </dl>
-
-
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,294 +1,217 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
 .TH "ZMAP" "1" "February 2024" "ZMap" "zmap"
-.
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
-.
 .SH "SYNOPSIS"
-zmap [ \-p <port(s)> ] [ \-o <outfile> ] [ OPTIONS\.\.\. ] [ ip/hostname/range ]
-.
+zmap [ \-p
 .SH "DESCRIPTION"
 \fIZMap\fR is a network tool for scanning the entire IPv4 address space (or large samples)\. ZMap is capable of scanning the entire Internet in around 45 minutes on a gigabit network connection, reaching ~98% theoretical line speed\.
-.
 .SH "OPTIONS"
-.
 .SS "BASIC OPTIONS"
-.
 .TP
 \fBip\fR/\fBhostname\fR/\fBrange\fR
 IP addresses or DNS hostnames to scan\. Accepts IP ranges in CIDR block notation\. Defaults to 0\.0\.0/8
-.
 .TP
 \fB\-p\fR, \fB\-\-target\-ports=port(s)\fR
 List of TCP/UDP ports and/or port ranges to scan (e\.g\., 80,443,100\-105)\. Use \'*\' to scan all ports, including port 0\.
-.
 .TP
 \fB\-o\fR, \fB\-\-output\-file=name\fR
 When using an output module that uses a file, write results to this file\. Use \- for stdout\.
-.
 .TP
 \fB\-b\fR, \fB\-\-blocklist\-file=path\fR
 File of subnets to exclude, in CIDR notation, one\-per line\. It is recommended you use this to exclude RFC 1918 addresses, multicast, IANA reserved space, and other IANA special\-purpose addresses\. An example blocklist file \fBblocklist\.conf\fR for this purpose\.
-.
 .TP
 \fB\-w\fR, \fB\-\-allowlist\-file=path\fR
 File of subnets to scan, in CIDR notation, one\-per line\. Specifying a allowlist file is equivalent to specifying to ranges directly on the command line interface, but allows specifying a large number of subnets\. Note: if you are specifying a large number of individual IP addresses (more than 10 million), you should instead use \fB\-\-list\-of\-ips\-file\fR\.
-.
 .TP
 \fB\-I\fR, \fB\-\-list\-of\-ips\-file=path\fR
 File of individual IP addresses to scan, one\-per line\. This feature allows you to scan a large number of unrelated addresses\. If you have a small number of IPs, it is faster to specify these on the command line or by using \fB\-\-allowlist\-file\fR\. This should only be used when scanning more than 10 million addresses\. When used in with \-\-allowlist\-path, only hosts in the intersection of both sets will be scanned\. Hosts specified here, but included in the blocklist will be excluded\.
-.
 .SS "SCAN OPTIONS"
-.
 .TP
 \fB\-r\fR, \fB\-\-rate=pps\fR
 Set the send rate in packets/sec\. Note: when combined with \-\-probes, this is total packets per second, not IPs per second\. Setting the rate to 0 will scan at full line rate\. Default: 10000 pps\.
-.
 .TP
 \fB\-B\fR, \fB\-\-bandwidth=bps\fR
 Set the send rate in bits/second (supports suffixes G, M, and K (e\.g\. \-B 10M for 10 mbps)\. This overrides the \-\-rate flag\.
-.
 .TP
 \fB\-n\fR, \fB\-\-max\-targets=n\fR
 Cap the number of targets to probe\. This can either be a number (e\.g\. \-n 1000) or a percentage (e\.g\. \-n 0\.1%) of the scannable address space (after excluding blocklist)\. A target is an IP/port pair, if scanning multiple ports, and an IP otherwise\.
-.
 .TP
 \fB\-N\fR, \fB\-\-max\-results=n\fR
 Exit after receiving this many results
-.
 .TP
 \fB\-t\fR, \fB\-\-max\-runtime=secs\fR
 Cap the length of time for sending packets
-.
 .TP
 \fB\-c\fR, \fB\-\-cooldown\-time=secs\fR
 How long to continue receiving after sending has completed (default=8)
-.
 .TP
 \fB\-e\fR, \fB\-\-seed=n\fR
 Seed used to select address permutation\. Use this if you want to scan addresses in the same order for multiple ZMap runs\.
-.
 .TP
 \fB\-P\fR, \fB\-\-probes=n\fR
 Number of probes to send to each IP/Port pair (default=1)\. Since ZMap composes Ethernet frames directly, probes can be lost en\-route to destination\. Increasing the \-\-probes increases the chance that an online host will receive a probe in an unreliable network\. This is contrasted with \fB\-\-retries\fR which just gives the number of attempts to send a single probe on the source NIC\.
-.
 .TP
 \fB\-\-retries=n\fR
 Number of times to try resending a packet if the sendto call fails (default=10)
-.
 .TP
 \fB\-\-batch=n\fR
 Number of packets to batch before calling the appropriate syscall to send\. Used to take advantage of Linux\'s \fBsendmmsg\fR syscall to send the entire batch at once\. Only available on Linux, other OS\'s will send each packet individually\. (default=64)
-.
 .SS "SCAN SHARDING"
-.
 .TP
 \fB\-\-shards=N\fR
 Split the scan up into N shards/partitions among different instances of zmap (default=1)\. When sharding, \fB\-\-seed\fR is required\.
-.
 .TP
 \fB\-\-shard=n\fR
 Set which shard to scan (default=0)\. Shards are 0\-indexed in the range [0, N), where N is the total number of shards\. When sharding \fB\-\-seed\fR is required\.
-.
 .SS "NETWORK OPTIONS"
-.
 .TP
 \fB\-s\fR, \fB\-\-source\-port=port|range\fR
 Source port(s) to send packets from
-.
 .TP
 \fB\-S\fR, \fB\-\-source\-ip=ip|range\fR
 Source address(es) to send packets from\. Either single IP or range (e\.g\. 10\.0\.0\.1\-10\.0\.0\.9)
-.
 .TP
 \fB\-G\fR, \fB\-\-gateway\-mac=addr\fR
 Gateway MAC address to send packets to (in case auto\-detection fails)
-.
 .TP
 \fB\-\-source\-mac=addr\fR
 Source MAC address to send packets from (in case auto\-detection fails)
-.
 .TP
 \fB\-i\fR, \fB\-\-interface=name\fR
 Network interface to use
-.
 .TP
 \fB\-X\fR, \fB\-\-iplayer\fR
 Send IP layer packets instead of ethernet packets (for non\-Ethernet interface)
-.
+.TP
+\fB\-\-netmap\-wait\-ping=ip\fR
+(Netmap only) Wait for ip to respond to ICMP Echo request before commencing scan\. Useful if connected to a switch with STP enabled, where the PHY reset that is needed for entering and leaving Netmap mode will cause the switch to mute the port until the spanning tree protocol has determined that the link should be set into forward state\.
 .SS "PROBE OPTIONS"
 ZMap allows users to specify and write their own probe modules\. Probe modules are responsible for generating probe packets to send, and processing responses from hosts\.
-.
 .TP
 \fB\-\-list\-probe\-modules\fR
 List available probe modules (e\.g\. tcp_synscan)
-.
 .TP
 \fB\-M\fR, \fB\-\-probe\-module=name\fR
 Select probe module (default=tcp_synscan)
-.
 .TP
 \fB\-\-probe\-args=args\fR
 Arguments to pass to probe module
-.
 .TP
 \fB\-\-probe\-ttl=hops\fR
 Set TTL value for probe IP packets
-.
 .TP
 \fB\-\-list\-output\-fields\fR
 List the fields the selected probe module can send to the output module
-.
 .SS "OUTPUT OPTIONS"
 ZMap allows users to specify and write their own output modules for use with ZMap\. Output modules are responsible for processing the fieldsets returned by the probe module, and outputting them to the user\. Users can specify output fields, and write filters over the output fields\.
-.
 .TP
 \fB\-\-list\-output\-modules\fR
 List available output modules (e\.g\. csv)
-.
 .TP
 \fB\-O\fR, \fB\-\-output\-module=name\fR
 Select output module (default=csv)
-.
 .TP
 \fB\-\-output\-args=args\fR
 Arguments to pass to output module
-.
 .TP
 \fB\-f\fR, \fB\-\-output\-fields=fields\fR
 Comma\-separated list of fields to output
-.
 .TP
 \fB\-\-output\-filter\fR
 Specify an output filter over the fields defined by the probe module\. See the output filter section for more details\.
-.
 .TP
 \fB\-\-no\-header\-row\fR
 Excludes any header rows (e\.g\., CSV header fields) from ZMap output\. This is useful if you\'re piping results into another application that expects only data\.
-.
 .SS "RESPONSE DEDUPLICATION"
 Hosts will oftentimes send multiple responses to a probe (either because the scanner doesn\'t send back a RST packet or because the host has a misimplemented TCP stack\. To address this, ZMap will attempt to deduplicate responsive (ip,port) targets\.
-.
 .TP
 \fB\-\-dedup\-method\fR
 Specifies the method ZMap will use to deduplicate responses\. Options are: full, window, and none\. Full deduplication uses a 32\-bit bitmap and guarantees that no duplicates will be emitted\. However, full\-deduplication requires around 500MB of memory for a single port\. We do not support full deduplication for multiple ports\. Window uses a sliding window of a the last (user\-defined) number of responses as set by \-\-dedup\-window\-size\. None will prevent any deduplication\.
-.
 .TP
 \fB\-\-dedup\-window\-size=targets\fR
 Specifies the size of the sliding window of last n target responses to be used for deduplication\. Only applicable if using window deduplication\.
-.
 .SS "LOGGING AND METADATA OPTIONS"
-.
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Do not print status updates once per second
-.
 .TP
 \fB\-v\fR, \fB\-\-verbosity=n\fR
 Level of log detail (0\-5, default=3)
-.
 .TP
 \fB\-l\fR, \fB\-\-log\-file=filename\fR
 Output file for log messages\. By default, stderr\.
-.
 .TP
 \fB\-m\fR, \fB\-\-metadata\-file=filename\fR
 Output file for scan metadata (JSON)
-.
 .TP
 \fB\-L\fR, \fB\-\-log\-directory\fR
 Write log entries to a timestamped file in this directory
-.
 .TP
 \fB\-u\fR, \fB\-\-status\-updates\-file\fR
 Write scan progress updates to CSV file"
-.
 .TP
 \fB\-\-disable\-syslog\fR
 Disables logging messages to syslog
-.
 .TP
 \fB\-\-notes\fR
 Inject user\-specified notes into scan metadata
-.
 .TP
 \fB\-\-user\-metadata\fR
 Inject user\-specified JSON metadata into scan metadata
-.
 .SS "ADDITIONAL OPTIONS"
-.
 .TP
 \fB\-T\fR, \fB\-\-sender\-threads=n\fR
 Threads used to send packets\. ZMap will attempt to detect the optimal number of send threads based on the number of processor cores\. Defaults to min(4, number of processor cores on host \- 1)\.
-.
 .TP
 \fB\-C\fR, \fB\-\-config=filename\fR
 Read a configuration file, which can specify any other options\.
-.
 .TP
 \fB\-d\fR, \fB\-\-dryrun\fR
 Print out each packet to stdout instead of sending it (useful for debugging)
-.
 .TP
 \fB\-\-max\-sendto\-failures\fR
 Maximum NIC sendto failures before scan is aborted
-.
 .TP
 \fB\-\-min\-hitrate\fR
 Minimum hitrate that scan can hit before scan is aborted
-.
 .TP
 \fB\-\-cores\fR
 Comma\-separated list of cores to pin to
-.
 .TP
 \fB\-\-ignore\-blocklist\-errors\fR
 Ignore invalid, malformed, or unresolvable entries in allowlist/blocklist file\. Replaces the pre\-v3\.x \fB\-\-ignore\-invalid\-hosts\fR option\.
-.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help and exit
-.
 .TP
 \fB\-V\fR, \fB\-\-version\fR
 Print version and exit
-.
 .SS "OUTPUT FILTERS"
 Results generated by a probe module can be filtered before being passed to the output module\. Filters are defined over the output fields of a probe module\. Filters are written in a simple filtering language, similar to SQL, and are passed to ZMap using the \fB\-\-output\-filter\fR option\. Output filters are commonly used to filter out duplicate results, or to only pass only successful responses to the output module\.
-.
 .P
 Filter expressions are of the form \fB<fieldname> <operation> <value>\fR\. The type of \fB<value>\fR must be either a string or unsigned integer literal, and match the type of \fB<fieldname>\fR\. The valid operations for integer comparisons are = !=, \fI,\fR, \fI=,\fR=\. The operations for string comparisons are =, !=\. The \fB\-\-list\-output\-fields\fR flag will print what fields and types are available for the selected probe module, and then exit\.
-.
 .P
 Compound filter expressions may be constructed by combining filter expressions using parenthesis to specify order of operations, the && (logical AND) and || (logical OR) operators\.
-.
 .P
 For example, a filter for only successful, non\-duplicate responses would be written as: \fB\-\-output\-filter="success = 1 && repeat = 0"\fR
-.
 .SS "UDP PROBE MODULE OPTIONS"
 These arguments are all passed using the \fB\-\-probe\-args=args\fR option\. Only one argument may be passed at a time\.
-.
 .TP
 \fBfile:/path/to/file\fR
 Path to payload file to send to each host over UDP\.
-.
 .TP
 \fBtemplate:/path/to/template\fR
 Path to template file\. For each destination host, the template file is populated, set as the UDP payload, and sent\.
-.
 .TP
 \fBtext:<text>\fR
 ASCII text to send to each destination host
-.
 .TP
 \fBhex:<hex>\fR
 Hex\-encoded binary to send to each destination host
-.
 .TP
 \fBtemplate\-fields\fR
 Print information about the allowed template fields and exit\.
-.
 .SS "MID\-SCAN CHANGES"
 You can change the rate at which ZMap is scanning mid\-scan by sending SIGUSR1 (increase) and SIGUSR2 (decrease) signals to ZMap\. These will result in the scan rate increasing or decreasing by 5%\.

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>zmap(1) - The Fast Internet Scanner</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -65,14 +65,15 @@
     <li class='tr'>zmap(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>zmap</code> - <span class="man-whatis">The Fast Internet Scanner</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p>zmap [ -p &lt;port(s)&gt; ] [ -o &lt;outfile&gt; ] [ OPTIONS... ] [ ip/hostname/range ]</p>
+<p>zmap [ -p <port> ] [ -o <outfile> ] [ OPTIONS... ] [ ip/hostname/range ]</outfile></port></p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -85,83 +86,148 @@ on a gigabit network connection, reaching ~98% theoretical line speed.</p>
 <h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
 
 <dl>
-<dt> <code>ip</code>/<code>hostname</code>/<code>range</code></dt><dd><p> IP addresses or DNS hostnames to scan. Accepts IP ranges in CIDR block
- notation. Defaults to 0.0.0/8</p></dd>
-<dt> <code>-p</code>, <code>--target-ports=port(s)</code></dt><dd><p> List of TCP/UDP ports and/or port ranges to scan (e.g., 80,443,100-105).
- Use '*' to scan all ports, including port 0.</p></dd>
-<dt> <code>-o</code>, <code>--output-file=name</code></dt><dd><p> When using an output module that uses a file, write results to this file.
- Use - for stdout.</p></dd>
-<dt> <code>-b</code>, <code>--blocklist-file=path</code></dt><dd><p> File of subnets to exclude, in CIDR notation, one-per line. It is
- recommended you use this to exclude RFC 1918 addresses, multicast, IANA
- reserved space, and other IANA special-purpose addresses. An example
- blocklist file <strong>blocklist.conf</strong> for this purpose.</p></dd>
-<dt> <code>-w</code>, <code>--allowlist-file=path</code></dt><dd><p>File of subnets to scan, in CIDR notation, one-per line. Specifying a
-allowlist file is equivalent to specifying to ranges directly on the command
-line interface, but allows specifying a large number of subnets. Note:
-if you are specifying a large number of individual IP addresses (more than
-10 million), you should instead use <code>--list-of-ips-file</code>.</p></dd>
-<dt> <code>-I</code>, <code>--list-of-ips-file=path</code></dt><dd><p>File of individual IP addresses to scan, one-per line. This feature allows you
-to scan a large number of unrelated addresses. If you have a small number of IPs,
-it is faster to specify these on the command
-line or by using <code>--allowlist-file</code>. This should only be used when scanning more than
-10 million addresses. When used in with --allowlist-path, only hosts in the intersection
-of both sets will be scanned. Hosts specified here, but included in the blocklist will
-be excluded.</p></dd>
+<dt>
+<code>ip</code>/<code>hostname</code>/<code>range</code>
+</dt>
+<dd>IP addresses or DNS hostnames to scan. Accepts IP ranges in CIDR block
+notation. Defaults to 0.0.0/8</dd>
+<dt>
+<code>-p</code>, <code>--target-ports=port(s)</code>
+</dt>
+<dd>List of TCP/UDP ports and/or port ranges to scan (e.g., 80,443,100-105).
+Use '*' to scan all ports, including port 0.</dd>
+<dt>
+<code>-o</code>, <code>--output-file=name</code>
+</dt>
+<dd>When using an output module that uses a file, write results to this file.
+Use - for stdout.</dd>
+<dt>
+<code>-b</code>, <code>--blocklist-file=path</code>
+</dt>
+<dd>File of subnets to exclude, in CIDR notation, one-per line. It is
+recommended you use this to exclude RFC 1918 addresses, multicast, IANA
+reserved space, and other IANA special-purpose addresses. An example
+blocklist file <strong>blocklist.conf</strong> for this purpose.</dd>
+<dt>
+<code>-w</code>, <code>--allowlist-file=path</code>
+</dt>
+<dd>    File of subnets to scan, in CIDR notation, one-per line. Specifying a
+    allowlist file is equivalent to specifying to ranges directly on the command
+    line interface, but allows specifying a large number of subnets. Note:
+    if you are specifying a large number of individual IP addresses (more than
+    10 million), you should instead use <code>--list-of-ips-file</code>.</dd>
+<dt>
+<code>-I</code>, <code>--list-of-ips-file=path</code>
+</dt>
+<dd>    File of individual IP addresses to scan, one-per line. This feature allows you
+    to scan a large number of unrelated addresses. If you have a small number of IPs,
+    it is faster to specify these on the command
+    line or by using <code>--allowlist-file</code>. This should only be used when scanning more than
+    10 million addresses. When used in with --allowlist-path, only hosts in the intersection
+    of both sets will be scanned. Hosts specified here, but included in the blocklist will
+    be excluded.</dd>
 </dl>
-
 
 <h3 id="SCAN-OPTIONS">SCAN OPTIONS</h3>
 
 <dl>
-<dt> <code>-r</code>, <code>--rate=pps</code></dt><dd><p> Set the send rate in packets/sec. Note: when combined with --probes,  this is
- total packets per second, not IPs per second. Setting the rate to 0 will scan
- at full line rate. Default: 10000 pps.</p></dd>
-<dt> <code>-B</code>, <code>--bandwidth=bps</code></dt><dd><p> Set the send rate in bits/second (supports suffixes G, M, and K (e.g. -B
- 10M for 10 mbps). This overrides the --rate flag.</p></dd>
-<dt> <code>-n</code>, <code>--max-targets=n</code></dt><dd><p> Cap the number of targets to probe. This can either be a number (e.g. -n
- 1000) or a percentage (e.g. -n 0.1%) of the scannable address space
- (after excluding blocklist). A target is an IP/port pair, if scanning multiple
- ports, and an IP otherwise.</p></dd>
-<dt> <code>-N</code>, <code>--max-results=n</code></dt><dd><p> Exit after receiving this many results</p></dd>
-<dt> <code>-t</code>, <code>--max-runtime=secs</code></dt><dd><p> Cap the length of time for sending packets</p></dd>
-<dt> <code>-c</code>, <code>--cooldown-time=secs</code></dt><dd><p> How long to continue receiving after sending has completed (default=8)</p></dd>
-<dt> <code>-e</code>, <code>--seed=n</code></dt><dd><p> Seed used to select address permutation. Use this if you want to scan
- addresses in the same order for multiple ZMap runs.</p></dd>
-<dt> <code>-P</code>, <code>--probes=n</code></dt><dd><p> Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet
- frames directly, probes can be lost en-route to destination. Increasing the
- --probes increases the chance that an online host will receive a probe in an
- unreliable network. This is contrasted with <code>--retries</code> which just gives the
- number of attempts to send a single probe on the source NIC.</p></dd>
-<dt> <code>--retries=n</code></dt><dd><p> Number of times to try resending a packet if the sendto call fails (default=10)</p></dd>
-<dt> <code>--batch=n</code></dt><dd><p> Number of packets to batch before calling the appropriate syscall to send. Used
- to take advantage of Linux's <code>sendmmsg</code> syscall to send the entire batch at once.
- Only available on Linux, other OS's will send each packet individually. (default=64)</p></dd>
+<dt>
+<code>-r</code>, <code>--rate=pps</code>
+</dt>
+<dd>Set the send rate in packets/sec. Note: when combined with --probes,  this is
+total packets per second, not IPs per second. Setting the rate to 0 will scan
+at full line rate. Default: 10000 pps.</dd>
+<dt>
+<code>-B</code>, <code>--bandwidth=bps</code>
+</dt>
+<dd>Set the send rate in bits/second (supports suffixes G, M, and K (e.g. -B
+10M for 10 mbps). This overrides the --rate flag.</dd>
+<dt>
+<code>-n</code>, <code>--max-targets=n</code>
+</dt>
+<dd>Cap the number of targets to probe. This can either be a number (e.g. -n
+1000) or a percentage (e.g. -n 0.1%) of the scannable address space
+(after excluding blocklist). A target is an IP/port pair, if scanning multiple
+ports, and an IP otherwise.</dd>
+<dt>
+<code>-N</code>, <code>--max-results=n</code>
+</dt>
+<dd>Exit after receiving this many results</dd>
+<dt>
+<code>-t</code>, <code>--max-runtime=secs</code>
+</dt>
+<dd>Cap the length of time for sending packets</dd>
+<dt>
+<code>-c</code>, <code>--cooldown-time=secs</code>
+</dt>
+<dd>How long to continue receiving after sending has completed (default=8)</dd>
+<dt>
+<code>-e</code>, <code>--seed=n</code>
+</dt>
+<dd>Seed used to select address permutation. Use this if you want to scan
+addresses in the same order for multiple ZMap runs.</dd>
+<dt>
+<code>-P</code>, <code>--probes=n</code>
+</dt>
+<dd>Number of probes to send to each IP/Port pair (default=1). Since ZMap composes Ethernet
+frames directly, probes can be lost en-route to destination. Increasing the
+--probes increases the chance that an online host will receive a probe in an
+unreliable network. This is contrasted with <code>--retries</code> which just gives the
+number of attempts to send a single probe on the source NIC.</dd>
+<dt><code>--retries=n</code></dt>
+<dd>Number of times to try resending a packet if the sendto call fails (default=10)</dd>
+<dt><code>--batch=n</code></dt>
+<dd>Number of packets to batch before calling the appropriate syscall to send. Used
+to take advantage of Linux's <code>sendmmsg</code> syscall to send the entire batch at once.
+Only available on Linux, other OS's will send each packet individually. (default=64)</dd>
 </dl>
-
 
 <h3 id="SCAN-SHARDING">SCAN SHARDING</h3>
 
 <dl>
-<dt> <code>--shards=N</code></dt><dd><p> Split the scan up into N shards/partitions among different instances of
- zmap (default=1). When sharding, <strong>--seed</strong> is required.</p></dd>
-<dt> <code>--shard=n</code></dt><dd><p> Set which shard to scan (default=0). Shards are 0-indexed in the range
- [0, N), where N is the    total number of shards. When sharding
- <strong>--seed</strong> is required.</p></dd>
+<dt><code>--shards=N</code></dt>
+<dd>Split the scan up into N shards/partitions among different instances of
+zmap (default=1). When sharding, <strong>--seed</strong> is required.</dd>
+<dt><code>--shard=n</code></dt>
+<dd>Set which shard to scan (default=0). Shards are 0-indexed in the range
+[0, N), where N is the    total number of shards. When sharding
+<strong>--seed</strong> is required.</dd>
 </dl>
-
 
 <h3 id="NETWORK-OPTIONS">NETWORK OPTIONS</h3>
 
 <dl>
-<dt> <code>-s</code>, <code>--source-port=port|range</code></dt><dd><p> Source port(s) to send packets from</p></dd>
-<dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
- 10.0.0.1-10.0.0.9)</p></dd>
-<dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>
-<dt> <code>--source-mac=addr</code></dt><dd><p> Source MAC address to send packets from (in case auto-detection fails)</p></dd>
-<dt> <code>-i</code>, <code>--interface=name</code></dt><dd><p> Network interface to use</p></dd>
-<dt> <code>-X</code>, <code>--iplayer</code></dt><dd><p> Send IP layer packets instead of ethernet packets (for non-Ethernet interface)</p></dd>
+<dt>
+<code>-s</code>, <code>--source-port=port|range</code>
+</dt>
+<dd>Source port(s) to send packets from</dd>
+<dt>
+<code>-S</code>, <code>--source-ip=ip|range</code>
+</dt>
+<dd>Source address(es) to send packets from. Either single IP or range (e.g.
+10.0.0.1-10.0.0.9)</dd>
+<dt>
+<code>-G</code>, <code>--gateway-mac=addr</code>
+</dt>
+<dd>Gateway MAC address to send packets to (in case auto-detection fails)</dd>
+<dt><code>--source-mac=addr</code></dt>
+<dd>Source MAC address to send packets from (in case auto-detection fails)</dd>
+<dt>
+<code>-i</code>, <code>--interface=name</code>
+</dt>
+<dd>Network interface to use</dd>
+<dt>
+<code>-X</code>, <code>--iplayer</code>
+</dt>
+<dd>Send IP layer packets instead of ethernet packets (for non-Ethernet interface)</dd>
+<dt><code>--netmap-wait-ping=ip</code></dt>
+<dd>(Netmap only)
+Wait for ip to respond to ICMP Echo request before commencing scan.
+Useful if connected to a switch with STP enabled, where the PHY reset
+that is needed for entering and leaving Netmap mode will cause the switch
+to mute the port until the spanning tree protocol has determined that
+the link should be set into forward state.</dd>
 </dl>
-
 
 <h3 id="PROBE-OPTIONS">PROBE OPTIONS</h3>
 
@@ -170,13 +236,19 @@ are responsible for generating probe packets to send, and processing responses
 from hosts.</p>
 
 <dl>
-<dt> <code>--list-probe-modules</code></dt><dd><p> List available probe modules (e.g. tcp_synscan)</p></dd>
-<dt> <code>-M</code>, <code>--probe-module=name</code></dt><dd><p> Select probe module (default=tcp_synscan)</p></dd>
-<dt> <code>--probe-args=args</code></dt><dd><p> Arguments to pass to probe module</p></dd>
-<dt> <code>--probe-ttl=hops</code></dt><dd><p> Set TTL value for probe IP packets</p></dd>
-<dt> <code>--list-output-fields</code></dt><dd><p> List the fields the selected probe module can send to the output module</p></dd>
+<dt><code>--list-probe-modules</code></dt>
+<dd>List available probe modules (e.g. tcp_synscan)</dd>
+<dt>
+<code>-M</code>, <code>--probe-module=name</code>
+</dt>
+<dd>Select probe module (default=tcp_synscan)</dd>
+<dt><code>--probe-args=args</code></dt>
+<dd>Arguments to pass to probe module</dd>
+<dt><code>--probe-ttl=hops</code></dt>
+<dd>Set TTL value for probe IP packets</dd>
+<dt><code>--list-output-fields</code></dt>
+<dd>List the fields the selected probe module can send to the output module</dd>
 </dl>
-
 
 <h3 id="OUTPUT-OPTIONS">OUTPUT OPTIONS</h3>
 
@@ -186,17 +258,26 @@ the probe module, and outputting them to the user. Users can specify output
 fields, and write filters over the output fields.</p>
 
 <dl>
-<dt> <code>--list-output-modules</code></dt><dd><p> List available output modules (e.g. csv)</p></dd>
-<dt> <code>-O</code>, <code>--output-module=name</code></dt><dd><p> Select output module (default=csv)</p></dd>
-<dt> <code>--output-args=args</code></dt><dd><p> Arguments to pass to output module</p></dd>
-<dt> <code>-f</code>, <code>--output-fields=fields</code></dt><dd><p> Comma-separated list of fields to output</p></dd>
-<dt> <code>--output-filter</code></dt><dd><p> Specify an output filter over the fields defined by the probe module. See
- the output filter section for more details.</p></dd>
-<dt> <code>--no-header-row</code></dt><dd><p> Excludes any header rows (e.g., CSV header fields) from ZMap output. This is
- useful if you're piping results into another application that expects only
- data.</p></dd>
+<dt><code>--list-output-modules</code></dt>
+<dd>List available output modules (e.g. csv)</dd>
+<dt>
+<code>-O</code>, <code>--output-module=name</code>
+</dt>
+<dd>Select output module (default=csv)</dd>
+<dt><code>--output-args=args</code></dt>
+<dd>Arguments to pass to output module</dd>
+<dt>
+<code>-f</code>, <code>--output-fields=fields</code>
+</dt>
+<dd>Comma-separated list of fields to output</dd>
+<dt><code>--output-filter</code></dt>
+<dd>Specify an output filter over the fields defined by the probe module. See
+the output filter section for more details.</dd>
+<dt><code>--no-header-row</code></dt>
+<dd>Excludes any header rows (e.g., CSV header fields) from ZMap output. This is
+useful if you're piping results into another application that expects only
+data.</dd>
 </dl>
-
 
 <h3 id="RESPONSE-DEDUPLICATION">RESPONSE DEDUPLICATION</h3>
 
@@ -206,51 +287,90 @@ TCP stack. To address this, ZMap will attempt to deduplicate responsive (ip,port
 targets.</p>
 
 <dl>
-<dt> <code>--dedup-method</code></dt><dd><p> Specifies the method ZMap will use to deduplicate responses. Options are:
- full, window, and none. Full deduplication uses a 32-bit bitmap and
- guarantees that no duplicates will be emitted. However, full-deduplication
- requires around 500MB of memory for a single port. We do not support full
- deduplication for multiple ports. Window uses a sliding window of a the last
- (user-defined) number of responses as set by --dedup-window-size. None will
- prevent any deduplication.</p></dd>
-<dt> <code>--dedup-window-size=targets</code></dt><dd><p> Specifies the size of the sliding window of last n target responses to be
- used for deduplication. Only applicable if using window deduplication.</p></dd>
+<dt><code>--dedup-method</code></dt>
+<dd>Specifies the method ZMap will use to deduplicate responses. Options are:
+full, window, and none. Full deduplication uses a 32-bit bitmap and
+guarantees that no duplicates will be emitted. However, full-deduplication
+requires around 500MB of memory for a single port. We do not support full
+deduplication for multiple ports. Window uses a sliding window of a the last
+(user-defined) number of responses as set by --dedup-window-size. None will
+prevent any deduplication.</dd>
+<dt><code>--dedup-window-size=targets</code></dt>
+<dd>Specifies the size of the sliding window of last n target responses to be
+used for deduplication. Only applicable if using window deduplication.</dd>
 </dl>
-
 
 <h3 id="LOGGING-AND-METADATA-OPTIONS">LOGGING AND METADATA OPTIONS</h3>
 
 <dl>
-<dt> <code>-q</code>, <code>--quiet</code></dt><dd><p> Do not print status updates once per second</p></dd>
-<dt> <code>-v</code>, <code>--verbosity=n</code></dt><dd><p> Level of log detail (0-5, default=3)</p></dd>
-<dt> <code>-l</code>, <code>--log-file=filename</code></dt><dd><p> Output file for log messages. By default, stderr.</p></dd>
-<dt> <code>-m</code>, <code>--metadata-file=filename</code></dt><dd><p> Output file for scan metadata (JSON)</p></dd>
-<dt> <code>-L</code>, <code>--log-directory</code></dt><dd><p> Write log entries to a timestamped file in this directory</p></dd>
-<dt> <code>-u</code>, <code>--status-updates-file</code></dt><dd><p> Write scan progress updates to CSV file"</p></dd>
-<dt> <code>--disable-syslog</code></dt><dd><p> Disables logging messages to syslog</p></dd>
-<dt> <code>--notes</code></dt><dd><p> Inject user-specified notes into scan metadata</p></dd>
-<dt> <code>--user-metadata</code></dt><dd><p> Inject user-specified JSON metadata into scan metadata</p></dd>
+<dt>
+<code>-q</code>, <code>--quiet</code>
+</dt>
+<dd>Do not print status updates once per second</dd>
+<dt>
+<code>-v</code>, <code>--verbosity=n</code>
+</dt>
+<dd>Level of log detail (0-5, default=3)</dd>
+<dt>
+<code>-l</code>, <code>--log-file=filename</code>
+</dt>
+<dd>Output file for log messages. By default, stderr.</dd>
+<dt>
+<code>-m</code>, <code>--metadata-file=filename</code>
+</dt>
+<dd>Output file for scan metadata (JSON)</dd>
+<dt>
+<code>-L</code>, <code>--log-directory</code>
+</dt>
+<dd>Write log entries to a timestamped file in this directory</dd>
+<dt>
+<code>-u</code>, <code>--status-updates-file</code>
+</dt>
+<dd>Write scan progress updates to CSV file"</dd>
+<dt><code>--disable-syslog</code></dt>
+<dd>Disables logging messages to syslog</dd>
+<dt><code>--notes</code></dt>
+<dd>Inject user-specified notes into scan metadata</dd>
+<dt><code>--user-metadata</code></dt>
+<dd>Inject user-specified JSON metadata into scan metadata</dd>
 </dl>
-
 
 <h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
 
 <dl>
-<dt> <code>-T</code>, <code>--sender-threads=n</code></dt><dd><p> Threads used to send packets. ZMap will attempt to detect the optimal
- number of send threads based on the number of processor cores. Defaults to
- min(4, number of processor cores on host - 1).</p></dd>
-<dt> <code>-C</code>, <code>--config=filename</code></dt><dd><p> Read a configuration file, which can specify any other options.</p></dd>
-<dt> <code>-d</code>, <code>--dryrun</code></dt><dd><p> Print out each packet to stdout instead of sending it (useful for
- debugging)</p></dd>
-<dt> <code>--max-sendto-failures</code></dt><dd><p> Maximum NIC sendto failures before scan is aborted</p></dd>
-<dt> <code>--min-hitrate</code></dt><dd><p> Minimum hitrate that scan can hit before scan is aborted</p></dd>
-<dt> <code>--cores</code></dt><dd><p> Comma-separated list of cores to pin to</p></dd>
-<dt> <code>--ignore-blocklist-errors</code></dt><dd><p>  Ignore invalid, malformed, or unresolvable entries in allowlist/blocklist file.
-  Replaces the pre-v3.x <code>--ignore-invalid-hosts</code> option.</p></dd>
-<dt> <code>-h</code>, <code>--help</code></dt><dd><p> Print help and exit</p></dd>
-<dt> <code>-V</code>, <code>--version</code></dt><dd><p> Print version and exit</p></dd>
+<dt>
+<code>-T</code>, <code>--sender-threads=n</code>
+</dt>
+<dd>Threads used to send packets. ZMap will attempt to detect the optimal
+number of send threads based on the number of processor cores. Defaults to
+min(4, number of processor cores on host - 1).</dd>
+<dt>
+<code>-C</code>, <code>--config=filename</code>
+</dt>
+<dd>Read a configuration file, which can specify any other options.</dd>
+<dt>
+<code>-d</code>, <code>--dryrun</code>
+</dt>
+<dd>Print out each packet to stdout instead of sending it (useful for
+debugging)</dd>
+<dt><code>--max-sendto-failures</code></dt>
+<dd>Maximum NIC sendto failures before scan is aborted</dd>
+<dt><code>--min-hitrate</code></dt>
+<dd>Minimum hitrate that scan can hit before scan is aborted</dd>
+<dt><code>--cores</code></dt>
+<dd>Comma-separated list of cores to pin to</dd>
+<dt><code>--ignore-blocklist-errors</code></dt>
+<dd> Ignore invalid, malformed, or unresolvable entries in allowlist/blocklist file.
+ Replaces the pre-v3.x <code>--ignore-invalid-hosts</code> option.</dd>
+<dt>
+<code>-h</code>, <code>--help</code>
+</dt>
+<dd>Print help and exit</dd>
+<dt>
+<code>-V</code>, <code>--version</code>
+</dt>
+<dd>Print version and exit</dd>
 </dl>
-
 
 <h3 id="OUTPUT-FILTERS">OUTPUT FILTERS</h3>
 
@@ -261,9 +381,9 @@ passed to ZMap using the <code>--output-filter</code> option. Output filters are
 used to filter out duplicate results, or to only pass only successful responses
 to the output module.</p>
 
-<p>Filter expressions are of the form <code>&lt;fieldname> &lt;operation> &lt;value></code>. The type of
-<code>&lt;value></code> must be either a string or unsigned integer literal, and match the type
-of <code>&lt;fieldname></code>. The valid operations for integer comparisons are = !=, <var>, </var>,
+<p>Filter expressions are of the form <code>&lt;fieldname&gt; &lt;operation&gt; &lt;value&gt;</code>. The type of
+<code>&lt;value&gt;</code> must be either a string or unsigned integer literal, and match the type
+of <code>&lt;fieldname&gt;</code>. The valid operations for integer comparisons are = !=, <var>, </var>,
 <var>=, </var>=. The operations for string comparisons are =, !=. The
 <code>--list-output-fields</code> flag will print what fields and types are available for
 the selected probe module, and then exit.</p>
@@ -281,21 +401,24 @@ written as: <code>--output-filter="success = 1 &amp;&amp; repeat = 0"</code></p>
 argument may be passed at a time.</p>
 
 <dl>
-<dt> <code>file:/path/to/file</code></dt><dd><p> Path to payload file to send to each host over UDP.</p></dd>
-<dt> <code>template:/path/to/template</code></dt><dd><p> Path to template file. For each destination host, the template file is
- populated, set as the UDP payload, and sent.</p></dd>
-<dt> <code>text:&lt;text></code></dt><dd><p> ASCII text to send to each destination host</p></dd>
-<dt> <code>hex:&lt;hex></code></dt><dd><p>Hex-encoded binary to send to each destination host</p></dd>
-<dt> <code>template-fields</code></dt><dd><p> Print information about the allowed template fields and exit.</p></dd>
+<dt><code>file:/path/to/file</code></dt>
+<dd>Path to payload file to send to each host over UDP.</dd>
+<dt><code>template:/path/to/template</code></dt>
+<dd>Path to template file. For each destination host, the template file is
+populated, set as the UDP payload, and sent.</dd>
+<dt><code>text:&lt;text&gt;</code></dt>
+<dd>ASCII text to send to each destination host</dd>
+<dt><code>hex:&lt;hex&gt;</code></dt>
+<dd>    Hex-encoded binary to send to each destination host</dd>
+<dt><code>template-fields</code></dt>
+<dd>Print information about the allowed template fields and exit.</dd>
 </dl>
-
 
 <h3 id="MID-SCAN-CHANGES">MID-SCAN CHANGES</h3>
 
 <p>You can change the rate at which ZMap is scanning mid-scan by sending SIGUSR1 (increase)
 and SIGUSR2 (decrease) signals to ZMap. These will result in the scan rate increasing or
 decreasing by 5%.</p>
-
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -126,6 +126,14 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
    * `-X`, `--iplayer`:
      Send IP layer packets instead of ethernet packets (for non-Ethernet interface)
 
+   * `--netmap-wait-ping=ip`:
+     (Netmap only)
+     Wait for ip to respond to ICMP Echo request before commencing scan.
+     Useful if connected to a switch with STP enabled, where the PHY reset
+     that is needed for entering and leaving Netmap mode will cause the switch
+     to mute the port until the spanning tree protocol has determined that
+     the link should be set into forward state.
+
 ### PROBE OPTIONS ###
 
 ZMap allows users to specify and write their own probe modules. Probe modules

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -1046,6 +1046,10 @@ int main(int argc, char *argv[])
 		log_fatal("zmap", "timeout waiting for PHY reset to complete");
 	}
 	log_debug("zmap", "PHY reset is complete, link state is up");
+
+	if (args.netmap_wait_ping_arg != NULL) {
+		zconf.nm.wait_ping_dstip = string_to_ip_address(args.netmap_wait_ping_arg);
+	}
 #endif
 
 #ifndef PFRING

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -98,6 +98,9 @@ option "interface"              i "Specify network interface to use"
     optional string
 option "iplayer"                X "Sends IP packets instead of Ethernet (for VPNs)"
     optional
+option "netmap-wait-ping"       - "Wait for IP to respond to ping before commencing scan (netmap only)"
+    typestr="ip"
+    optional string
 
 section "Probe Modules"
 option "probe-module"           M "Select probe module"

--- a/src/ztee.1
+++ b/src/ztee.1
@@ -1,56 +1,39 @@
-.\" generated with Ronn/v0.7.3
-.\" http://github.com/rtomayko/ronn/tree/0.7.3
-.
-.TH "ZTEE" "1" "November 2023" "ZMap" "ztee"
-.
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "ZTEE" "1" "February 2024" "ZMap" "ztee"
 .SH "NAME"
 \fBztee\fR \- output buffer and splitter
-.
 .SH "SYNOPSIS"
-ztee [ OPTIONS\.\.\. ] [ FILE\.\.\. ]
-.
+ztee [ OPTIONS\|\.\|\.\|\. ] [ FILE\|\.\|\.\|\. ]
 .SH "DESCRIPTION"
 \fIZTee\fR is an output buffer and splitter for use with ZMap output data\. ZTee should be used whenever ZMap is piped into an application scanner, placed between ZMap and the application scanner\. ZTee writes the transformed output to stdout, and writes the original output to FILE\.
-.
 .P
 See \fB\-\-help\fR for examples\.
-.
 .SH "CSV PROCESSING AND RAW MODE"
 \fIZTee\fR operates by default on CSV\-format output from ZMap\. It only outputs IP addresses (from the input\'s \fBip\fR or \fBsaddr\fR field) to stdout, while writing all input to the output file\. ZTee does not print the first line of input to stdout, since that row is the CSV header\.
-.
 .P
 To operate on data in any other format, pass the \fB\-\-raw\fR flag\. In raw mode, ztee behaves like tee: it will not transform or attempt to parse the input data\.
-.
 .SH "OPTIONS"
-.
 .SS "BASIC OPTIONS"
-.
 .TP
 \fB\-r\fR, \fB\-\-raw\fR
 Ignore input formatting and pass through raw input\. This causes ztee to behave exactly like tee, with the addition of buffering\.
-.
 .TP
 \fB\-\-success\-only\fR
 Only write to stdout rows where success=1 or success=true\. Invalid in combination with \fB\-\-raw\fR\.
-.
 .TP
 \fB\-m\fR, \fB\-\-monitor\fR
 Print monitor data to stderr
-.
 .TP
 \fB\-u\fR, \fB\-\-status\-updates\-file\fR
 Write status updates (monitor data) to the given file, in CSV format
-.
 .TP
 \fB\-l\fR, \fB\-\-log\-file=name\fR
 Write errors etc\. to the given file\. If none, ZTee logs to stderr\.
-.
 .SS "ADDITIONAL OPTIONS"
-.
 .TP
 \fB\-h, \-\-help\fR
 Display help
-.
 .TP
 \fB\-V, \-\-version\fR
 Display version

--- a/src/ztee.1.html
+++ b/src/ztee.1.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv='content-type' value='text/html;charset=utf8'>
-  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.9.1 (http://github.com/apjanke/ronn-ng/tree/0.9.1)'>
   <title>ztee(1) - output buffer and splitter</title>
   <style type='text/css' media='all'>
   /* style: man */
@@ -66,11 +66,12 @@
     <li class='tr'>ztee(1)</li>
   </ol>
 
-  <h2 id="NAME">NAME</h2>
+  
+
+<h2 id="NAME">NAME</h2>
 <p class="man-name">
   <code>ztee</code> - <span class="man-whatis">output buffer and splitter</span>
 </p>
-
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
 <p>ztee [ OPTIONS... ] [ FILE... ]</p>
@@ -99,28 +100,40 @@ behaves like tee: it will not transform or attempt to parse the input data.</p>
 <h3 id="BASIC-OPTIONS">BASIC OPTIONS</h3>
 
 <dl>
-<dt><code>-r</code>, <code>--raw</code></dt><dd><p>Ignore input formatting and pass through raw input. This causes
-ztee to behave exactly like tee, with the addition of buffering.</p></dd>
-<dt><code>--success-only</code></dt><dd><p>Only write to stdout rows where success=1 or success=true. Invalid
-in combination with <code>--raw</code>.</p></dd>
-<dt><code>-m</code>, <code>--monitor</code></dt><dd><p>Print monitor data to stderr</p></dd>
-<dt><code>-u</code>, <code>--status-updates-file</code></dt><dd><p>Write status updates (monitor data) to the given file, in CSV format</p></dd>
-<dt><code>-l</code>, <code>--log-file=name</code></dt><dd><p>Write errors etc. to the given file. If none, ZTee logs to stderr.</p></dd>
+<dt>
+<code>-r</code>, <code>--raw</code>
+</dt>
+<dd>Ignore input formatting and pass through raw input. This causes
+ztee to behave exactly like tee, with the addition of buffering.</dd>
+<dt><code>--success-only</code></dt>
+<dd>Only write to stdout rows where success=1 or success=true. Invalid
+in combination with <code>--raw</code>.</dd>
+<dt>
+<code>-m</code>, <code>--monitor</code>
+</dt>
+<dd>Print monitor data to stderr</dd>
+<dt>
+<code>-u</code>, <code>--status-updates-file</code>
+</dt>
+<dd>Write status updates (monitor data) to the given file, in CSV format</dd>
+<dt>
+<code>-l</code>, <code>--log-file=name</code>
+</dt>
+<dd>Write errors etc. to the given file. If none, ZTee logs to stderr.</dd>
 </dl>
-
 
 <h3 id="ADDITIONAL-OPTIONS">ADDITIONAL OPTIONS</h3>
 
 <dl>
-<dt><code>-h, --help</code></dt><dd><p>Display help</p></dd>
-<dt><code>-V, --version</code></dt><dd><p>Display version</p></dd>
+<dt><code>-h, --help</code></dt>
+<dd>Display help</dd>
+<dt><code>-V, --version</code></dt>
+<dd>Display version</dd>
 </dl>
-
-
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>November 2023</li>
+    <li class='tc'>February 2024</li>
     <li class='tr'>ztee(1)</li>
   </ol>
 


### PR DESCRIPTION
Going into and leaving netmap mode causes the link to go down and up as
part of a PHY reset.  If the interface is connected to a switch with STP
enabled, then depending on port configuration, the switch might be
muting the port for as many as 30 seconds while the port goes through
the listening and learning STP states.

To work around this in situations where the switch cannot be
reconfigured, `--netmap-wait-ping` allows to wait for end-to-end ICMP
connectivity with an IP address before starting the scan.

Tested w/FreeBSD 14.0 on VM and bare metal.