### PR TITLE
Bump batch size from uint8_t to uint16_t

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -462,7 +462,7 @@ cleanup:
 	return EXIT_SUCCESS;
 }
 
-batch_t* create_packet_batch(uint8_t capacity) {
+batch_t* create_packet_batch(uint16_t capacity) {
 	// calculate how many bytes are needed for each component of a batch
 	int size_of_packet_array = MAX_PACKET_SIZE * capacity;
 	int size_of_ips_array = sizeof(uint32_t) * capacity;

--- a/src/send.h
+++ b/src/send.h
@@ -19,11 +19,11 @@ typedef struct {
 	char* packets;
 	uint32_t* ips;
 	int* lens;
-	uint8_t len;
-	uint8_t capacity;
+	uint16_t len;
+	uint16_t capacity;
 }batch_t;
 
-batch_t* create_packet_batch(uint8_t capacity);
+batch_t* create_packet_batch(uint16_t capacity);
 void free_packet_batch(batch_t* batch);
 
 #endif // SEND_H

--- a/src/state.h
+++ b/src/state.h
@@ -71,7 +71,7 @@ struct state_conf {
 	int cooldown_secs;
 	// number of sending threads
 	uint8_t senders;
-	uint8_t batch;
+	uint16_t batch;
 	uint32_t pin_cores_len;
 	uint32_t *pin_cores;
 	// should use CLI provided randomization seed instead of generating

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -915,10 +915,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (args.batch_given && args.batch_arg >= 1 && args.batch_arg <= UINT8_MAX) {
+	if (args.batch_given && args.batch_arg >= 1 && args.batch_arg <= UINT16_MAX) {
 		zconf.batch = args.batch_arg;
 	} else if (args.batch_given) {
-		log_fatal("zmap", "batch size must be > 0 and <= 255");
+		log_fatal("zmap", "batch size must be > 0 and <= 65535");
 	}
 
 	if (args.max_targets_given) {


### PR DESCRIPTION
I'd like to suggest to promote batch size to a uint16_t.  I am testing on 10GbE hardware on which batch size somewhere above 256 is currently a sweet spot (with netmap); the current uint8_t limits me to 255.  While there might be other perf improvements with bigger impact than what I see from batch size tuning, I see no real downside in allowing for a larger range of batch sizes.

Tested on macOS Sonoma and FreeBSD 14.0.