### PR TITLE
Fix a number of benign compiler warnings on Linux/GCC

### DIFF
--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <time.h>
 
 #include "../../lib/includes.h"
 #include "../../lib/xalloc.h"

--- a/src/probe_modules/packet.h
+++ b/src/probe_modules/packet.h
@@ -159,7 +159,7 @@ static inline int check_dst_port(uint16_t port, int num_ports,
 	if (min <= max) {
 		return (to_validate <= max && to_validate >= min);
 	} else {
-		return (to_validate <= max ^ to_validate >= min);
+		return ((to_validate <= max) != (to_validate >= min));
 	}
 }
 

--- a/src/recv.c
+++ b/src/recv.c
@@ -100,7 +100,7 @@ void handle_packet(uint32_t buflen, const u_char *bytes,
 	// Here, we fake an ethernet frame (which is initialized to
 	// have ETH_P_IP proto and 00s for dest/src).
 	if (zconf.send_ip_pkts) {
-		const static uint32_t available_space = sizeof(fake_eth_hdr) - sizeof(struct ether_header);
+		static const uint32_t available_space = sizeof(fake_eth_hdr) - sizeof(struct ether_header);
 		assert(buflen > (uint32_t)zconf.data_link_size);
 		buflen -= zconf.data_link_size;
 		if (buflen > available_space) {


### PR DESCRIPTION
```
src/recv.c:103:17: warning: ‘static’ is not at beginning of declaration [-Wold-style-declaration]
  103 |                 const static uint32_t available_space = sizeof(fake_eth_hdr) - sizeof(struct ether_header);
      |                 ^~~~~

src/if-netmap-linux.c: In function ‘fetch_stats64’: src/if-netmap-linux.c:94:18: warning: ISO C99 doesn’t support unnamed structs/unions [-Wpedantic]
   94 |                 };
      |                  ^

src/probe_modules/packet.h: In function ‘check_dst_port’: src/probe_modules/packet.h:162:37: warning: suggest parentheses around comparison in operand of ‘^’ -Wparentheses]
  162 |                 return (to_validate <= max ^ to_validate >= min);
      |                         ~~~~~~~~~~~~^~~~~~

src/probe_modules/packet.c: In function ‘set_timestamp_option_with_nops’: src/probe_modules/packet.c:178:24: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
  178 |         uint32_t now = time(NULL);
      |                        ^~~~
src/probe_modules/packet.c:178:24: warning: nested extern declaration of ‘time’ [-Wnested-externs]
  178 |         uint32_t now = time(NULL);
      |                        ^~~~
```