### PR TITLE
Generalise zqueue to non-string data pointers, fix memory leaks

### DIFF
--- a/lib/queue.c
+++ b/lib/queue.c
@@ -34,12 +34,12 @@ zqueue_t *queue_init(void)
 
 int is_empty(zqueue_t *queue) { return queue->size == 0; }
 
-void push_back(char *data, zqueue_t *queue)
+void push_back(void *data, zqueue_t *queue)
 {
 	znode_t *new_node = xmalloc(sizeof(znode_t));
 	new_node->prev = NULL;
 	new_node->next = NULL;
-	new_node->data = strdup(data);
+	new_node->data = data;
 
 	pthread_mutex_lock(&queue->lock);
 	if (is_empty(queue)) {
@@ -86,8 +86,7 @@ znode_t *get_front(zqueue_t *queue)
 		pthread_cond_wait(&queue->empty, &queue->lock);
 	}
 
-	znode_t *temp = xmalloc(sizeof(znode_t));
-	temp = queue->front;
+	znode_t *temp = queue->front;
 	pthread_mutex_unlock(&queue->lock);
 	return temp;
 }
@@ -100,8 +99,7 @@ znode_t *get_back(zqueue_t *queue)
 		pthread_cond_wait(&queue->empty, &queue->lock);
 	}
 
-	znode_t *temp = xmalloc(sizeof(znode_t));
-	temp = queue->back;
+	znode_t *temp = queue->back;
 	pthread_mutex_unlock(&queue->lock);
 	return temp;
 }

--- a/lib/queue.h
+++ b/lib/queue.h
@@ -23,7 +23,7 @@
 #include <pthread.h>
 
 typedef struct zqueue_node {
-	char *data;
+	void *data;
 	struct zqueue_node *prev;
 	struct zqueue_node *next;
 } znode_t;
@@ -39,7 +39,7 @@ typedef struct zqueue {
 
 zqueue_t *queue_init(void);
 int is_empty(zqueue_t *queue);
-void push_back(char *data, zqueue_t *queue);
+void push_back(void *data, zqueue_t *queue);
 znode_t *pop_front(zqueue_t *queue);
 znode_t *pop_front_unsafe(zqueue_t *queue);
 znode_t *get_front(zqueue_t *queue);

--- a/src/ztee.c
+++ b/src/ztee.c
@@ -334,7 +334,7 @@ void *process_queue(void *arg)
 		pthread_mutex_unlock(&queue->lock);
 
 		// Write raw data to output file
-		fprintf(output_file, "%s", node->data);
+		fprintf(output_file, "%s", (char *)node->data);
 		fflush(output_file);
 		if (ferror(output_file)) {
 			log_fatal("ztee", "Error writing to output file");
@@ -346,11 +346,11 @@ void *process_queue(void *arg)
 			log_fatal("ztee", "JSON input format unimplemented");
 			break;
 		case FORMAT_CSV:
-			print_from_csv(node->data);
+			print_from_csv((char *)node->data);
 			break;
 		default:
 			// Handle raw
-			fprintf(stdout, "%s", node->data);
+			fprintf(stdout, "%s", (char *)node->data);
 			break;
 		}
 
@@ -383,7 +383,7 @@ void *read_in(void *arg)
 
 	// Read in from stdin and add to back of linked list
 	while (getline(&input, &length, stdin) > 0) {
-		push_back(input, queue);
+		push_back((void *)strdup(input), queue);
 
 		total_read_in++;
 		read_in_last_sec++;


### PR DESCRIPTION
Make zqueue store a `void *` instead of a `char *`.

Remove internal strdup of data ptr in push_back; instead, take ownership of the pointer and move the strdup to the callsite in ztee.

This also fixes a one-off memory leak in ztee where first_line was never freed after getting pushed onto the queue.

While here, fix memory leaks in the unused get_front and get_back functions.

Generalisation of zqueue motivated by wanting to use zqueue for [droe/netmap-arp](https://github.com/droe/zmap/tree/droe/netmap-arp).