### PR TITLE
netmap: Reply to ARP requests from gateway for scan source IPs

### DIFF
--- a/src/recv-netmap.c
+++ b/src/recv-netmap.c
@@ -74,6 +74,12 @@ submit_packet(make_packet_func_t mkpkt, void const *arg)
 	submit_batch_internal(batch); // consumes batch
 }
 
+// In netmap mode, the OS network stack never gets to see incoming packets
+// unless we explicitly forward them to the host rings; hence the kernel will
+// not be responding to ARP requests.  To remove the need for static ARP
+// entries on the gateway, respond to ARP requests from the gateway for any of
+// the source IPs of the scan.
+
 #define ARP_ETHER_INET_PKT_LEN (sizeof(struct ether_header) + sizeof(struct arphdr) + 2 * ETHER_ADDR_LEN + 2 * sizeof(uint32_t))
 #define x_ar_sha(ap) ((uint8_t *)((ap) + 1))
 #define x_ar_spa(ap) (((uint8_t *)((ap) + 1)) + ETHER_ADDR_LEN)

--- a/src/send-internal.h
+++ b/src/send-internal.h
@@ -16,6 +16,9 @@ int send_batch(sock_t sock, batch_t *batch, int retries);
 
 #if defined(PFRING)
 #include "send-pfring.h"
+#elif defined(NETMAP)
+void submit_batch_internal(batch_t *batch);
+int send_batch_internal(sock_t sock, batch_t *batch);
 #elif defined(__linux__)
 #include "send-linux.h"
 #endif

--- a/src/send-netmap.c
+++ b/src/send-netmap.c
@@ -20,16 +20,32 @@
 #include <errno.h>
 #include <string.h>
 #include <assert.h>
+#include <pthread.h>
 
 #include "../lib/includes.h"
 #include "../lib/logger.h"
+#include "../lib/queue.h"
 
 #include "socket.h"
 #include "state.h"
 
+static pthread_once_t submit_queue_inited = PTHREAD_ONCE_INIT;
+static zqueue_t *submit_queue;
+
+static void
+submit_queue_init_once(void)
+{
+	submit_queue = queue_init();
+	assert(submit_queue);
+}
+
 int
 send_run_init(sock_t sock)
 {
+	if (sock.nm.tx_ring_idx == 0) {
+		pthread_once(&submit_queue_inited, submit_queue_init_once);
+	}
+
 	struct pollfd fds = {
 		.fd = sock.nm.tx_ring_fd,
 		.events = POLLOUT,
@@ -42,27 +58,23 @@ send_run_init(sock_t sock)
 	return 0;
 }
 
-// This implementation does not use attempts, because retries do not
-// make sense based on the premise that syncing a TX ring will never
-// fail for transient reasons.
-//
-// This implementation never reports batches as partially failed,
-// because the netmap API does not have partial failure semantics.
-// All we know is that a poll or ioctl syscall failed, not if or
-// how many of the packets we placed in the ringbuffer were sent.
-//
-// ZMap's current architecture forces us to copy packet data here.
-// An even more optimised implementation might reuse packet data
-// in buffers (unless NS_BUF_CHANGED has been set by the kernel on
-// a slot), and only update the fields that need to change, such
-// as dst IP, checksum etc depending on scan type and params.
-int
-send_batch(sock_t sock, batch_t *batch, UNUSED int attempts)
+// Called from the recv thread to submit a batch of packets
+// for sending on thread 0; typically batch size is just 1.
+// Used for responding to ARP requests.
+// The way this works is rather inefficient and only makes
+// sense for low volume packets.
+// Since we don't know if send_run_init() has been called
+// yet or not, we need to ensure the queue is initialized.
+void
+submit_batch_internal(batch_t *batch)
 {
-	if (batch->len == 0) {
-		return 0;
-	}
+	pthread_once(&submit_queue_inited, submit_queue_init_once);
+	push_back((void *)batch, submit_queue);
+}
 
+int
+send_batch_internal(sock_t sock, batch_t *batch)
+{
 	struct netmap_ring *ring = NETMAP_TXRING(zconf.nm.nm_if, sock.nm.tx_ring_idx);
 	struct pollfd fds = {
 		.fd = sock.nm.tx_ring_fd,
@@ -95,4 +107,48 @@ send_batch(sock_t sock, batch_t *batch, UNUSED int attempts)
 	}
 
 	return batch->len;
+}
+
+// Netmap's send_batch does not use attempts, because retries do
+// not make sense based on the premise that syncing a TX ring will
+// never fail for transient reasons.
+//
+// Netmap's send_batch never reports batches as partially failed,
+// because the netmap API does not have partial failure semantics.
+// All we know is that a poll or ioctl syscall failed, not if or
+// how many of the packets we placed in the ringbuffer were sent.
+//
+// There is a bit of unused optimization potential here; ZMap's
+// current architecture requires us to copy packet data on the
+// send path, we cannot supply netmap buffers to ZMap to write
+// into directly.  And even though netmap would allow us to reuse
+// data still in buffers (unless NS_BUF_CHANGED has been set by
+// the kernel), we cannot take advantage of that currently.
+int
+send_batch(sock_t sock, batch_t *batch, UNUSED int attempts)
+{
+	// On send thread 0, send any batches that have been
+	// submitted onto the submit_queue before sending the
+	// actual batch.  There should only be packets in the
+	// submit_queue very infrequently.
+	if (sock.nm.tx_ring_idx == 0) {
+		while (!is_empty(submit_queue)) {
+			znode_t *node = pop_front(submit_queue);
+			batch_t *extra_batch = (batch_t *)node->data;
+			assert(extra_batch->len > 0);
+			free(node);
+			if (send_batch_internal(sock, extra_batch) != extra_batch->len) {
+				log_error("send-netmap", "Failed to send extra batch of %u submitted packet(s)", extra_batch->len);
+			} else {
+				log_debug("send-netmap", "Sent extra batch of %u submitted packet(s)", extra_batch->len);
+			}
+			free_packet_batch(extra_batch);
+		}
+	}
+
+	if (batch->len == 0) {
+		return 0;
+	}
+
+	return send_batch_internal(sock, batch);
 }


### PR DESCRIPTION
In netmap mode, the OS network stack never gets to see incoming packets unless we explicitly forward them to the host rings; hence the kernel will not be responding to ARP requests.  To remove the need for static ARP entries on the gateway, respond to ARP requests from the gateway for any of the source IPs of the scan.

The recv thread can now submit packets for sending to send thread 0 via a zqueue.  This is used to respond to ARP requests that arrive after having let loose the send threads.  While still waiting for end-to-end connectivity with `--netmap-wait-ping`, ARP requests are responded to by sending directly from the recv thread, just like the ICMP Echo requests.

I did not see any significant netmap perf change from this at 10 GbE.

Tested on both FreeBSD and Linux.  Verified to correctly respond both to arping, as well as to real ARP by deleting ARP entries from the gateway's ARP table and observing the ARP table getting repopulated as well as packets on the wire.