### PR TITLE
Do not skip elements >= (1 << 48) w/o checking for sentinel

### DIFF
--- a/src/shard.c
+++ b/src/shard.c
@@ -157,10 +157,8 @@ target_t shard_get_cur_target(shard_t *shard)
 
 static inline uint64_t shard_get_next_elem(shard_t *shard)
 {
-	do {
-		shard->current *= shard->params.factor;
-		shard->current %= shard->params.modulus;
-	} while (shard->current >= (1LL << 48));
+	shard->current *= shard->params.factor;
+	shard->current %= shard->params.modulus;
 	return (uint64_t)shard->current;
 }
 


### PR DESCRIPTION
Fixes issue where scan would not terminate when one of the sentinel values is outside the 48 bit range (`shard->params.last >= (1 << 48)`).  This can only happen with the largest group (p: 2^48 + 23) and would be more likely to happen with many threads / shards.

Testing performed:
- `test/test-shard.sh` and `test/test_big_group.sh` still succeed
- smoke tested with a couple of scans

Possibly root cause of #809.