### PR TITLE
Smaller MAX_PACKET_SIZE and better batch cache locality

### DIFF
--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -62,7 +62,7 @@ int upnp_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	       MAX_PACKET_SIZE);
 
 	assert(MAX_PACKET_SIZE - ((char *)payload - (char *)buf) >
-	       (int)strlen(upnp_query));
+	       strlen(upnp_query));
 	strcpy(payload, upnp_query);
 
 	return EXIT_SUCCESS;

--- a/src/probe_modules/packet.h
+++ b/src/probe_modules/packet.h
@@ -18,11 +18,10 @@
 #include "../../lib/blocklist.h"
 #include "../../lib/pbm.h"
 #include "../state.h"
+#include "../send.h"
 
 #ifndef PACKET_H
 #define PACKET_H
-
-#define MAX_PACKET_SIZE 4096
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 

--- a/src/recv-netmap.c
+++ b/src/recv-netmap.c
@@ -50,9 +50,9 @@ send_packet(make_packet_func_t mkpkt, void const *arg)
 	sock.nm.tx_ring_fd = zconf.nm.nm_fd;
 
 	batch_t *batch = create_packet_batch(1);
-	batch->lens[0] = (int)mkpkt((uint8_t *)batch->packets, arg);
-	assert(batch->lens[0] <= MAX_PACKET_SIZE);
-	batch->ips[0] = 0; // unused by netmap
+	batch->packets[0].ip = 0; // unused by netmap
+	batch->packets[0].len = mkpkt(batch->packets[0].buf, arg);
+	assert(batch->packets[0].len <= MAX_PACKET_SIZE);
 	batch->len = 1;
 	if (send_batch_internal(sock, batch) != 1) {
 		log_fatal("recv-netmap", "Failed to send packet: %d: %s", errno, strerror(errno));
@@ -67,9 +67,9 @@ static void
 submit_packet(make_packet_func_t mkpkt, void const *arg)
 {
 	batch_t *batch = create_packet_batch(1);
-	batch->lens[0] = (int)mkpkt((uint8_t *)batch->packets, arg);
-	assert(batch->lens[0] <= MAX_PACKET_SIZE);
-	batch->ips[0] = 0; // unused by netmap
+	batch->packets[0].ip = 0; // unused by netmap
+	batch->packets[0].len = mkpkt(batch->packets[0].buf, arg);
+	assert(batch->packets[0].len <= MAX_PACKET_SIZE);
 	batch->len = 1;
 	submit_batch_internal(batch); // consumes batch
 }

--- a/src/send-bsd.c
+++ b/src/send-bsd.c
@@ -87,7 +87,7 @@ send_batch(sock_t sock, batch_t* batch, int retries)
 	int rc = 0;
 	for (int packet_num = 0; packet_num < batch->len; packet_num++) {
 		for (int retry_ct = 0; retry_ct < retries; retry_ct++) {
-			rc = send_packet(sock, ((uint8_t *)batch->packets) + (packet_num * MAX_PACKET_SIZE), batch->lens[packet_num], retry_ct);
+			rc = send_packet(sock, batch->packets[packet_num].buf, batch->packets[packet_num].len, retry_ct);
 			if (rc >= 0) {
 				packets_sent++;
 				break;
@@ -96,7 +96,7 @@ send_batch(sock_t sock, batch_t* batch, int retries)
 		if (rc < 0) {
 			// packet couldn't be sent in retries number of attempts
 			struct in_addr addr;
-			addr.s_addr = batch->ips[packet_num];
+			addr.s_addr = batch->packets[packet_num].ip;
 			char addr_str_buf[INET_ADDRSTRLEN];
 			const char *addr_str =
 			    inet_ntop(

--- a/src/send-linux.c
+++ b/src/send-linux.c
@@ -77,8 +77,8 @@ int send_batch(sock_t sock, batch_t* batch, int retries) {
 
 	for (int i = 0; i < batch->len; ++i) {
 		struct iovec *iov = &iovs[i];
-	    	iov->iov_base = ((void *)batch->packets) + (i * MAX_PACKET_SIZE);
-	       	iov->iov_len = batch->lens[i];
+		iov->iov_base = batch->packets[i].buf;
+		iov->iov_len = batch->packets[i].len;
 		struct msghdr *msg = &msgs[i];
 		memset(msg, 0, sizeof(struct msghdr));
 		// based on https://github.com/torvalds/linux/blob/master/net/socket.c#L2180
@@ -87,7 +87,7 @@ int send_batch(sock_t sock, batch_t* batch, int retries) {
 		msg->msg_iov = iov;
 		msg->msg_iovlen = 1;
 		msgvec[i].msg_hdr = *msg;
-		msgvec[i].msg_len = batch->lens[i];
+		msgvec[i].msg_len = batch->packets[i].len;
 	}
 	// set up per-retry variables, so we can only re-submit what didn't send successfully
 	struct mmsghdr* current_msg_vec = msgvec;

--- a/src/send-netmap.c
+++ b/src/send-netmap.c
@@ -89,12 +89,9 @@ send_batch_internal(sock_t sock, batch_t *batch)
 			return -1;
 		}
 
-		void *src_buf = (void *)((uint8_t *)batch->packets + i * MAX_PACKET_SIZE);
-		int len = batch->lens[i];
-		assert((uint32_t)len <= ring->nr_buf_size);
-
-		void *dst_buf = NETMAP_BUF(ring, ring->slot[ring->cur].buf_idx);
-		memcpy(dst_buf, src_buf, len);
+		uint32_t len = batch->packets[i].len;
+		assert(len <= ring->nr_buf_size);
+		memcpy(NETMAP_BUF(ring, ring->slot[ring->cur].buf_idx), batch->packets[i].buf, len);
 		ring->slot[ring->cur].len = len;
 		ring->head = ring->cur = nm_ring_next(ring, ring->cur);
 	}

--- a/src/send.h
+++ b/src/send.h
@@ -15,10 +15,21 @@
 iterator_t *send_init(void);
 int send_run(sock_t, shard_t *);
 
+// Fit two packets with metadata into one 4k page.
+// 2k seems like more than enough with typical MTU of
+// 1500, and we don't want to cause IP fragmentation.
+#define MAX_PACKET_SIZE (2048 - 2 * sizeof(uint32_t))
+
+// Metadata and initial packet bytes are adjacent,
+// for cache locality esp. with short packets.
+struct batch_packet {
+	uint32_t ip;
+	uint32_t len;
+	uint8_t buf[MAX_PACKET_SIZE];
+};
+
 typedef struct {
-	char* packets;
-	uint32_t* ips;
-	int* lens;
+	struct batch_packet *packets;
 	uint16_t len;
 	uint16_t capacity;
 }batch_t;

--- a/src/state.h
+++ b/src/state.h
@@ -23,7 +23,6 @@
 #include "filter.h"
 #include "types.h"
 
-#define MAX_PACKET_SIZE 4096
 #define MAC_ADDR_LEN_BYTES 6
 
 #define DEDUP_METHOD_DEFAULT 0


### PR DESCRIPTION
This is a very arguable change, feel free to reject.  I'm seeing a consistent ~ 0.7 % send rate improvement with lower-end hardware at 10 GbE close to but not quite at max send rate.

- Change how batch is laid out in memory:  Since all access is one packet at a time and never all IPs or all lengths, lay out all fields pertaining to the same packet adjacent in memory, for sequential access (single array of packets with metadata instead of separate arrays for packet data, lengths and ips)
- Reduce `MAX_PACKET_SIZE` from 4k to 2k minus metadata, which is still way above the standard MTU of 1500 that we probably don't want to exceed in order to avoid IP fragmentation

Extra benefits:
- Arguably cleaner code for accessing the packets in batches (no manual offset calculations)
- Single definition of `MAX_PACKET_SIZE` instead of the previous two definitions of `MAX_PACKET_SIZE`

Tested on the usual macOS Sonoma, FreeBSD 14 and Ubuntu 23.10 with and without netmap.