### PR TITLE
Bump -std to gnu11 for static assertions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 set(JUDY_LIBRARIES "Judy")
 
 # Standard FLAGS
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
 if(NOT APPLE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 endif()

--- a/src/if-netmap-linux.c
+++ b/src/if-netmap-linux.c
@@ -94,7 +94,7 @@ fetch_stats64(struct rtnl_link_stats64 *rtlstats64, char const *ifname, int nlrt
 			} err;
 		} u;
 	} nlresp;
-	_Static_assert(sizeof(nlresp.u.ans) >= sizeof(nlresp.u.err));
+	static_assert(sizeof(nlresp.u.ans) >= sizeof(nlresp.u.err), "ans is at least as large as err");
 	static const size_t ans_size = offsetof(struct nlresp, u.ans) + sizeof(nlresp.u.ans);
 	static const size_t err_size = offsetof(struct nlresp, u.err) + sizeof(nlresp.u.err);
 


### PR DESCRIPTION
I'd like to suggest bumping the C standard from GNU C99 to GNU C11.  C11 has been around for sufficiently long that I don't think there are substantial risks or portability limitations associated with targeting C11 anymore, and there seem to be zero changes to the codebase required.

Motivation is mainly support for static assertions (compile-time assertions).  On clang and GCC they do compile with GNU C99, but will emit compiler warnings that they need C11 on at least GCC.