### PR TITLE
Don't tell user to use 0 cores on machines with only 1 core

### DIFF
--- a/src/zmap.c
+++ b/src/zmap.c
@@ -1073,19 +1073,13 @@ int main(int argc, char *argv[])
 		sender_cap = 1;
 	}
 	if (zconf.senders > sender_cap) {
-		char recommended_cores[128];
-		snprintf(recommended_cores, sizeof(recommended_cores), "(number of cores - 1 = %d)", sender_cap);
-		if (zconf.senders > sender_cap && get_num_cores() == 1) {
-			strncpy(recommended_cores, "1\0", 3);
-		}
 		log_warn(
 		    "zmap",
 		    "ZMap has been configured to use a larger number of sending threads (%d) than the number of "
-		    "dedicated cores that can be assigned to sending packets. We advise using only "
-		    "%s sender threads such that every sender thread and the "
-		    "one receiver thread each have a dedicated core. Using a large number of sender threads "
+		    "dedicated cores (%d) that can be assigned to sending packets. We advise using a sending thread per CPU "
+		    "core while reserving one core for packet receiving and monitoring. Using a large number of sender threads "
 		    "will likely decrease performance, not increase it.",
-		    zconf.senders, recommended_cores);
+		    zconf.senders, get_num_cores());
 	}
 #else
 	zconf.senders = args.sender_threads_arg;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -1068,14 +1068,24 @@ int main(int argc, char *argv[])
 	}
 	// reserving 1 core for the receiver/monitor thread
 	int sender_cap = get_num_cores() - 1;
+	if (sender_cap < 1) {
+		// we need at least 1 core to send
+		sender_cap = 1;
+	}
 	if (zconf.senders > sender_cap) {
+		char recommended_cores[128];
+		snprintf(recommended_cores, sizeof(recommended_cores), "(number of cores - 1 = %d)", sender_cap);
+		if (zconf.senders > sender_cap && get_num_cores() == 1) {
+			strncpy(recommended_cores, "1\0", 3);
+		}
 		log_warn(
 		    "zmap",
 		    "ZMap has been configured to use a larger number of sending threads (%d) than the number of "
-			"dedicated cores that can be assigned to sending packets. We advise using only "
-			"(number of cores - 1 = %d) sender threads such that every sender thread and the "
-			"one receiver thread each have a dedicated core. Using a large number of sender threads "
-			"will likely decrease performance, not increase it.", zconf.senders, sender_cap);
+		    "dedicated cores that can be assigned to sending packets. We advise using only "
+		    "%s sender threads such that every sender thread and the "
+		    "one receiver thread each have a dedicated core. Using a large number of sender threads "
+		    "will likely decrease performance, not increase it.",
+		    zconf.senders, recommended_cores);
 	}
 #else
 	zconf.senders = args.sender_threads_arg;


### PR DESCRIPTION
Was testing something else on a 1 core VM and noticed that even if you put `-T 1`, you were warned you were using too many sending threads.

Tests
- Tested on 1 core VM with `-T 1` (no warning) and `-T 2` (warning)
- Tested on multi-core VM and behavior was as expected