### PR TITLE
Fix being unable to open an `IP layer` socket on Linux

### DIFF
--- a/src/socket-linux.c
+++ b/src/socket-linux.c
@@ -20,7 +20,7 @@ sock_t get_socket(UNUSED uint32_t id)
 {
 	int sock;
 	if (zconf.send_ip_pkts) {
-		sock = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_ALL));
+		sock = socket(PF_INET, SOCK_RAW, IPPROTO_RAW);
 	} else {
 		sock = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 	}

--- a/test/integration-tests/test_scan.py
+++ b/test/integration-tests/test_scan.py
@@ -26,3 +26,26 @@ def test_scan_known_good_ips():
     # clean up
     os.remove(output_file_path)
 
+
+def test_scan_known_good_ips_with_iplayer():
+    """
+    This test will scan (not dry run) known active IPs and check that they are all scanned
+    """
+    known_active_ips = ["1.1.1.1", "8.8.8.8"]
+    # create file called "output.txt" in current directory
+    with open(output_file_path, 'w') as file:
+        file.write("")
+    # using known dns resolvers to make this test deterministic
+    t = zmap_wrapper.Wrapper(dryrun=False, port=53, subnet=" ".join(known_active_ips), threads=1, output_file=output_file_path, max_cooldown=3, iplayer=True)
+    t.run()
+    # read the file into a list of IPs
+    ips = []
+    with open(output_file_path, 'r') as file:
+        for line in file:
+            ips.append(line.strip())
+
+    for ip in known_active_ips:
+        assert ip in ips, "an expected IP was not scanned"
+    # clean up
+    os.remove(output_file_path)
+

--- a/test/integration-tests/test_scan.py
+++ b/test/integration-tests/test_scan.py
@@ -30,6 +30,7 @@ def test_scan_known_good_ips():
 def test_scan_known_good_ips_with_iplayer():
     """
     This test will scan (not dry run) known active IPs and check that they are all scanned
+    Uses the --iplayer flag to test only sending IP packets (lets the OS compose the Ethernet frame)
     """
     known_active_ips = ["1.1.1.1", "8.8.8.8"]
     # create file called "output.txt" in current directory


### PR DESCRIPTION
Noticed while testing out #820 that the `--iplayer` option on Linux wasn't working. After trying several commits stretching back to December 2023, I guess this bug has been there this whole time. Thanks to @droe for the fix. Closes #821 

Changes
- Added integration test testing scanning known good ups with `--iplayer`
- Fixed bug so linux can open correct socket with `--iplayer`

Tests

- [x] Ubuntu box with `--iplayer` flag
- [x] Ubuntu box with `--iplayer` flag and Wireguard VPN enabled
- [x] Cloud VM (Digital Ocean Droplet)
