### PR TITLE
Capped percent complete in monitor.c

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -258,6 +258,11 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	exp->total_sent = total_sent;
 	exp->total_tried_sent = total_iterations;
 	exp->percent_complete = 100. * age / (age + remaining_secs);
+	if (exp->percent_complete > 100.) {
+		// can't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
+		// because for some CLI options (-N) you don't know how many packets you need to send to hit the target.
+		exp->percent_complete = 100.
+	}
 	exp->recv_success_unique = recv_success;
 	exp->app_recv_success_unique = app_success;
 	exp->total_recv = total_recv;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -160,14 +160,14 @@ double compute_remaining_time(double age, uint64_t packets_sent,
 		}
 		double remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
 		if (remaining_time < 0) {
-			// time_remaining cannot be less than zero
+			// remaining time cannot be less than zero
 			return 0;
 		}
 		return remaining_time;
 	} else {
 		double remaining_time = zconf.cooldown_secs - (now() - zsend.finish);
 		if (remaining_time < 0) {
-			// time_remaining cannot be less than zero
+			// remaining time cannot be less than zero
 			return 0;
 		}
 		return remaining_time;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -259,9 +259,9 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	exp->total_tried_sent = total_iterations;
 	exp->percent_complete = 100. * age / (age + remaining_secs);
 	if (exp->percent_complete > 100.) {
-		// can't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
+		// Shouldn't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
 		// because for some CLI options (-N) you don't know how many packets you need to send to hit the target.
-		exp->percent_complete = 100.
+		exp->percent_complete = 100.;
 	}
 	exp->recv_success_unique = recv_success;
 	exp->app_recv_success_unique = app_success;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -158,14 +158,14 @@ double compute_remaining_time(double age, uint64_t packets_sent,
 			remaining[4] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
 		}
-		remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
+		double remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
 		if (remaining_time < 0) {
 			// time_remaining cannot be less than zero
 			return 0;
 		}
 		return remaining_time;
 	} else {
-		remaining_time = zconf.cooldown_secs - (now() - zsend.finish);
+		double remaining_time = zconf.cooldown_secs - (now() - zsend.finish);
 		if (remaining_time < 0) {
 			// time_remaining cannot be less than zero
 			return 0;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -158,17 +158,19 @@ double compute_remaining_time(double age, uint64_t packets_sent,
 			remaining[4] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
 		}
-		// time_remaining cannot be less than zero
-		if (min_d(remaining, sizeof(remaining) / sizeof(double)) < 0) {
+		remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
+		if (remaining_time < 0) {
+			// time_remaining cannot be less than zero
 			return 0;
 		}
-		return min_d(remaining, sizeof(remaining) / sizeof(double));
+		return remaining_time;
 	} else {
-		// time_remaining cannot be less than zero
-		if (zconf.cooldown_secs - (now() - zsend.finish) < 0) {
+		remaining_time = zconf.cooldown_secs - (now() - zsend.finish);
+		if (remaining_time < 0) {
+			// time_remaining cannot be less than zero
 			return 0;
 		}
-		return zconf.cooldown_secs - (now() - zsend.finish);
+		return remaining_time;
 	}
 }
 


### PR DESCRIPTION
Resolves #823 

Saw with an assert that _sometimes_, the `remaining_secs` was < 0, causing our % remaining calculation to go over 100.
```
Mar 15 19:48:19.739 [WARN] monitor: rest = 2.043692
zmap: /home/pstephens/zmap-dev/src/monitor.c:165: compute_remaining_time: Assertion `zconf.cooldown_secs - (now() - zsend.finish) >= 0' failed.
```

I'm not entirely sure how this is happening, but this fix seems both relatively reasonable and sufficient to prevent it happening again.