### PR TITLE
Error out if user uses > 255 Sending Threads

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -258,6 +258,11 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	exp->total_sent = total_sent;
 	exp->total_tried_sent = total_iterations;
 	exp->percent_complete = 100. * age / (age + remaining_secs);
+	if (exp->percent_complete > 100.) {
+		// can't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
+		// because for some CLI options (-N) you don't know how many packets you need to send to hit the target.
+		exp->percent_complete = 100.
+	}
 	exp->recv_success_unique = recv_success;
 	exp->app_recv_success_unique = app_success;
 	exp->total_recv = total_recv;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -259,9 +259,9 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	exp->total_tried_sent = total_iterations;
 	exp->percent_complete = 100. * age / (age + remaining_secs);
 	if (exp->percent_complete > 100.) {
-		// can't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
+		// Shouldn't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
 		// because for some CLI options (-N) you don't know how many packets you need to send to hit the target.
-		exp->percent_complete = 100.
+		exp->percent_complete = 100.;
 	}
 	exp->recv_success_unique = recv_success;
 	exp->app_recv_success_unique = app_success;

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -258,11 +258,6 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	exp->total_sent = total_sent;
 	exp->total_tried_sent = total_iterations;
 	exp->percent_complete = 100. * age / (age + remaining_secs);
-	if (exp->percent_complete > 100.) {
-		// Shouldn't have over 100% completion. Also we can't do something like 100 * (pkts_sent / pkts_left)
-		// because for some CLI options (-N) you don't know how many packets you need to send to hit the target.
-		exp->percent_complete = 100.;
-	}
 	exp->recv_success_unique = recv_success;
 	exp->app_recv_success_unique = app_success;
 	exp->total_recv = total_recv;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -1042,6 +1042,11 @@ int main(int argc, char *argv[])
 #ifndef PFRING
 	// Set the correct number of threads, default to min(4, number of cores on host - 1, as available)
 	if (args.sender_threads_given) {
+		if (args.sender_threads_arg > 255) {
+			log_fatal("zmap", "cannot use > 255 sending threads. We advise using a sending thread per CPU "
+					  "core while reserving one core for packet receiving and monitoring. Using a large number of sender threads "
+					  "will likely decrease performance, not increase it.");
+		}
 		zconf.senders = args.sender_threads_arg;
 	} else {
 		// use one fewer than the number of cores on the machine such that the


### PR DESCRIPTION
Not sure why any user would _want_ to use this many, but since we're using a `uint_8` to store the number of sending threads, `> 255` wraps around. This leads to an unexpected number of sending threads used, at least from a user's perspective that doesn't know this detail. Setting a `log_fatal` to prevent this.