### PR TITLE
Fix more mostly benign Linux/GCC compiler warnings

### DIFF
--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -634,7 +634,7 @@ static int dns_global_initialize(struct state_conf *conf)
 			uint domain_len = strlen(domain_token);
 			// add space for the null terminator
 			char* domain_ptr = xmalloc(domain_len + 1);
-			strncpy(domain_ptr, domain_token, domain_len);
+			strncpy(domain_ptr, domain_token, domain_len + 1);
 			// add null terminator
 			domain_ptr[domain_len] = '\0';
 

--- a/src/send-linux.c
+++ b/src/send-linux.c
@@ -36,6 +36,9 @@
 #include "./send-linux.h"
 #include "state.h"
 
+// Dummy sockaddr for sendto
+static struct sockaddr_ll sockaddr;
+
 int send_run_init(sock_t s)
 {
 	// Get the actual socket

--- a/src/send-linux.h
+++ b/src/send-linux.h
@@ -21,7 +21,4 @@
 #include "../lib/includes.h"
 
 
-// Dummy sockaddr for sendto
-static struct sockaddr_ll sockaddr;
-
 #endif /* ZMAP_SEND_LINUX_H */

--- a/src/send.c
+++ b/src/send.c
@@ -278,6 +278,7 @@ int send_run(sock_t st, shard_t *s)
 			last_time = steady_now();
 		}
 	}
+	int attempts = zconf.retries + 1;
 	// Get the initial IP to scan.
 	target_t current = shard_get_cur_target(s);
 	uint32_t current_ip = current.ip;
@@ -300,7 +301,6 @@ int send_run(sock_t st, shard_t *s)
 			}
 		}
 	}
-	int attempts = zconf.retries + 1;
 	while (1) {
 		// Adaptive timing delay
 		if (count && delay > 0) {


### PR DESCRIPTION
```
In file included from src/send-internal.h:23,
                 from src/send.c:31:
src/send-linux.h:25:27: warning: ‘sockaddr’ defined but not used [-Wunused-variable]
   25 | static struct sockaddr_ll sockaddr;
      |                           ^~~~~~~~
src/send.c: In function ‘send_run’:
src/send.c:457:30: warning: ‘attempts’ may be used uninitialized [-Wmaybe-uninitialized]
  457 |         if (!zconf.dryrun && send_batch(st, batch, attempts) < 0) {
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/send.c:303:13: note: ‘attempts’ was declared here
  303 |         int attempts = zconf.retries + 1;
      |             ^~~~~~~~
src/probe_modules/module_dns.c: In function ‘dns_global_initialize’:
src/probe_modules/module_dns.c:637:25: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  637 |                         strncpy(domain_ptr, domain_token, domain_len);
      |                         ^
src/probe_modules/module_dns.c:634:43: note: length computed here
  634 |                         uint domain_len = strlen(domain_token);
      |                                           ^~~~~~~~~~~~~~~~~~~~
```