### PR TITLE
Output the progress once more when the whole scan process finished

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -16,6 +16,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -469,7 +470,7 @@ void monitor_run(iterator_t *it, pthread_mutex_t *lock)
 	int_status_t *internal_status = xmalloc(sizeof(int_status_t));
 	export_status_t *export_status = xmalloc(sizeof(export_status_t));
 
-	while (1) {
+	while (true) {
 		update_pcap_stats(lock);
 		export_stats(internal_status, export_status, it);
 		log_drop_warnings(export_status);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -469,7 +469,7 @@ void monitor_run(iterator_t *it, pthread_mutex_t *lock)
 	int_status_t *internal_status = xmalloc(sizeof(int_status_t));
 	export_status_t *export_status = xmalloc(sizeof(export_status_t));
 
-	while (!(zsend.complete && zrecv.complete)) {
+	while (1) {
 		update_pcap_stats(lock);
 		export_stats(internal_status, export_status, it);
 		log_drop_warnings(export_status);
@@ -486,6 +486,9 @@ void monitor_run(iterator_t *it, pthread_mutex_t *lock)
 		}
 		if (status_fd) {
 			update_status_updates_file(export_status, status_fd);
+		}
+		if (zsend.complete && zrecv.complete) {
+			break;
 		}
 		sleep(UPDATE_INTERVAL);
 	}


### PR DESCRIPTION
#### Introduction

As the issue (#823) montioned, the status output lacks the final line, which is crucial **for certain monitoring systems that track scanning progress via status files**. As a result, these systems are currently unable to accurately capture the completion of the scanning process.

> For comprehensive background information, refer to issue #823.

#### Overview of Current Issue

> Prior to the proposed changes, the status output format is as follows:

```bash
real-time,time-elapsed,time-remaining,percent-complete,hit-rate,active-send-threads,sent-total,sent-last-one-sec,sent-avg-per-sec,recv-success-total,recv-success-last-one-sec,recv-success-avg-per-sec,recv-total,recv-total-last-one-sec,recv-total-avg-per-sec,pcap-drop-total,drop-last-one-sec,drop-avg-per-sec,sendto-fail-total,sendto-fail-last-one-sec,sendto-fail-avg-per-sec
2024-03-16 10:24:50,0,11,0.249121,0.000000,4,2,1,68,0,0,0,0,0,0,0,0,0,0,0,0
...
2024-03-16 10:24:58,8,0,99.590841,19.531250,0,256,1,4009,50,0,6,200,50,25,0,0,0,0,0,0
```

#### Proposed Enhancement

With the proposed modifications, the status output format will be updated to include the final line, thereby providing a complete overview of the scanning progress:

```bash
real-time,time-elapsed,time-remaining,percent-complete,hit-rate,active-send-threads,sent-total,sent-last-one-sec,sent-avg-per-sec,recv-success-total,recv-success-last-one-sec,recv-success-avg-per-sec,recv-total,recv-total-last-one-sec,recv-total-avg-per-sec,pcap-drop-total,drop-last-one-sec,drop-avg-per-sec,sendto-fail-total,sendto-fail-last-one-sec,sendto-fail-avg-per-sec
2024-03-16 10:24:50,0,11,0.249121,0.000000,4,2,1,68,0,0,0,0,0,0,0,0,0,0,0,0
...
2024-03-16 10:24:58,8,0,99.590841,19.531250,0,256,1,4009,50,0,6,200,50,25,0,0,0,0,0,0
```