### PR TITLE
Fix incorrect status ETA and percent complete for multi-port scans with `--list-of-ips` and `--rate`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,9 @@
-Zakir Durumeric <zakir@umich.edu>
-David Adrian <davadria@umich.edu>
-Eric Wustrow <ewust@umich.edu>
+Zakir Durumeric <zakir@cs.stanford.edu>
+David Adrian <davidcadrian@gmail.com>
+Phillip Stephens <phillip4@stanford.edu>
+Daniel Roethlisberger <daniel@roe.ch>
+Eric Wustrow <ewust@colorado.edu>
 J. Alex Halderman <jhalderm@umich.edu>
-Paul Pearce <pearce@cs.berkeley.edu>
+Paul Pearce <pearce@gatech.edu>
 Ariana Mirian <amirian@umich.edu>
 HD Moore <HD_Moore@rapid7.com>

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -123,61 +123,47 @@ static double min_d(double array[], int n)
 double compute_remaining_time(double age, uint64_t packets_sent,
 			      uint64_t iterations)
 {
-	log_warn("compute_remaining_time", "age: %f, packets_sent: %d, iterations: %d", age, packets_sent, iterations);
 	if (!zsend.complete) {
 		double remaining[] = {INFINITY, INFINITY, INFINITY, INFINITY,
 				      INFINITY};
 		if (zsend.list_of_ips_pbm) {
-			log_warn("compute_remaining_time", "zsend.list_of_ips_pbm");
 			// Estimate progress using group iterations
 			double done =
 			    (double)iterations /
 			    ((uint64_t)0xFFFFFFFFU / zconf.total_shards);
 			remaining[0] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
-			log_warn("compute_remaining_time", "done: %f, remaining: %f", done, remaining[0]);
 		}
 		if (zsend.max_targets) {
-			log_warn("compute_remaining_time", "zsend.max_targets");
-			log_warn("compute_remaining_time", "packets_sent: %d, max_targets: %d, packet_streams: %d, total_shards: %d", packets_sent, zsend.max_targets, zconf.packet_streams, zconf.total_shards);
 			double done =
 			    (double)packets_sent /
 			    ((uint64_t)zsend.max_targets *
 			     zconf.packet_streams / zconf.total_shards);
 			remaining[1] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
-			log_warn("compute_remaining_time", "done: %f, remaining: %f", done, remaining[1]);
 		}
 		if (zconf.max_runtime) {
-			log_warn("compute_remaining_time", "zconf.max_runtime");
 			remaining[2] =
 			    (zconf.max_runtime - age) + zconf.cooldown_secs;
-			log_warn("compute_remaining_time", "remaining: %f", remaining[2]);
 		}
 		if (zconf.max_results) {
-			log_warn("compute_remaining_time", "zconf.max_results: %d", zconf.max_results);
 			double done =
 			    (double)zrecv.filter_success / zconf.max_results;
 			remaining[3] = (1. - done) * (age / done);
-			log_warn("compute_remaining_time", "remaining: %f", remaining[3]);
 		}
 		if (zsend.max_index) {
-			log_warn("compute_remaining_time", "zsend.max_index");
-			log_warn("compute_remaining_time", "max_index: %d", zsend.max_index);
 			double done =
 			    (double)packets_sent /
 			    ((uint64_t)zsend.max_index * zconf.ports->port_count * zconf.packet_streams /
 			     zconf.total_shards);
 			remaining[4] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
-			log_warn("compute_remaining_time", "remaining: %f", remaining[4]);
 		}
 		double remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
 		if (remaining_time < 0) {
 			// remaining time cannot be less than zero
 			return 0;
 		}
-		log_warn("compute_remaining_time", "FINAL remaining_time: %f", remaining_time);
 		return remaining_time;
 	} else {
 		double remaining_time = zconf.cooldown_secs - (now() - zsend.finish);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -123,47 +123,61 @@ static double min_d(double array[], int n)
 double compute_remaining_time(double age, uint64_t packets_sent,
 			      uint64_t iterations)
 {
+	log_warn("compute_remaining_time", "age: %f, packets_sent: %d, iterations: %d", age, packets_sent, iterations);
 	if (!zsend.complete) {
 		double remaining[] = {INFINITY, INFINITY, INFINITY, INFINITY,
 				      INFINITY};
 		if (zsend.list_of_ips_pbm) {
+			log_warn("compute_remaining_time", "zsend.list_of_ips_pbm");
 			// Estimate progress using group iterations
 			double done =
 			    (double)iterations /
 			    ((uint64_t)0xFFFFFFFFU / zconf.total_shards);
 			remaining[0] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
+			log_warn("compute_remaining_time", "done: %f, remaining: %f", done, remaining[0]);
 		}
 		if (zsend.max_targets) {
+			log_warn("compute_remaining_time", "zsend.max_targets");
+			log_warn("compute_remaining_time", "packets_sent: %d, max_targets: %d, packet_streams: %d, total_shards: %d", packets_sent, zsend.max_targets, zconf.packet_streams, zconf.total_shards);
 			double done =
 			    (double)packets_sent /
 			    ((uint64_t)zsend.max_targets *
 			     zconf.packet_streams / zconf.total_shards);
 			remaining[1] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
+			log_warn("compute_remaining_time", "done: %f, remaining: %f", done, remaining[1]);
 		}
 		if (zconf.max_runtime) {
+			log_warn("compute_remaining_time", "zconf.max_runtime");
 			remaining[2] =
 			    (zconf.max_runtime - age) + zconf.cooldown_secs;
+			log_warn("compute_remaining_time", "remaining: %f", remaining[2]);
 		}
 		if (zconf.max_results) {
+			log_warn("compute_remaining_time", "zconf.max_results: %d", zconf.max_results);
 			double done =
 			    (double)zrecv.filter_success / zconf.max_results;
 			remaining[3] = (1. - done) * (age / done);
+			log_warn("compute_remaining_time", "remaining: %f", remaining[3]);
 		}
 		if (zsend.max_index) {
+			log_warn("compute_remaining_time", "zsend.max_index");
+			log_warn("compute_remaining_time", "max_index: %d", zsend.max_index);
 			double done =
 			    (double)packets_sent /
-			    ((uint64_t)zsend.max_index * zconf.packet_streams /
+			    ((uint64_t)zsend.max_index * zconf.ports->port_count * zconf.packet_streams /
 			     zconf.total_shards);
 			remaining[4] =
 			    (1. - done) * (age / done) + zconf.cooldown_secs;
+			log_warn("compute_remaining_time", "remaining: %f", remaining[4]);
 		}
 		double remaining_time = min_d(remaining, sizeof(remaining) / sizeof(double));
 		if (remaining_time < 0) {
 			// remaining time cannot be less than zero
 			return 0;
 		}
+		log_warn("compute_remaining_time", "FINAL remaining_time: %f", remaining_time);
 		return remaining_time;
 	} else {
 		double remaining_time = zconf.cooldown_secs - (now() - zsend.finish);

--- a/test/integration-tests/test_dryrun_tcp.py
+++ b/test/integration-tests/test_dryrun_tcp.py
@@ -415,34 +415,8 @@ def test_list_of_ips_option():
     """
     scan using a list of IPs and ensure the correct IPs are scanned
     """
-    subnet_pattern = r'\b(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}\b'
-    # read in blocked subnets in file "blocklist.conf" into a list
-    blocked_subnets = []
-    with open("../../conf/blocklist.conf", "r") as file:
-        for line in file:
-            if not line.startswith("#") and "/" in line:
-                # need to use a regex to pull out the subnet
-                subnet = re.findall(subnet_pattern, line.strip())
-                if subnet:
-                    blocked_subnets.append(subnet[0])
 
-    # generate a list of 1M random, non-blocked public IPs
-    ips = []
-    for _ in range(1000):
-        while (True):
-            ip = str(ipaddress.IPv4Address(int(2 ** 32 * random.random())))
-            # ensure the IP is not in the blocklist
-            if any(ipaddress.ip_address(ip) in ipaddress.ip_network(subnet) for subnet in blocked_subnets):
-                # IP is blocked
-                continue
-            if ipaddress.ip_address(ip).is_global and not ipaddress.ip_address(ip).is_reserved:
-                # found a good IP
-                ips.append(ip)
-                break
-    # write the IPs to a file
-    with open("ips.txt", "w") as file:
-        for ip in ips:
-            file.write(ip + "\n")
+    ips = utils.write_ips_to_file(1000, "ips.txt")
     packets = zmap_wrapper.Wrapper(threads=2, list_of_ips_file="ips.txt").run()
 
     actual_packet_ips = list(packet["ip"]["daddr"] for packet in packets)

--- a/test/integration-tests/test_dryrun_tcp.py
+++ b/test/integration-tests/test_dryrun_tcp.py
@@ -111,26 +111,6 @@ def test_multi_port_with_subnet_and_threads():
                 assert_expected_ips_and_ports_were_scanned(expected_ips, expected_port_set, packet_list)
 
 
-def test_multi_port_with_list_of_ips_option():
-    """
-    scan a list of random IPs with multiple ports and ensure all IP/port combinations are scanned
-    """
-    port_tests = ["22-24"]
-    expected_ports = [utils.parse_ports_string(port_test) for port_test in port_tests]
-    expected_ips = set(str(ip) for ip in utils.write_ips_to_file(10000, "ips.txt"))
-
-    for port_test_index in range(len(port_tests)):
-        expected_port_set = set(expected_ports[port_test_index])
-        packet_list = zmap_wrapper.Wrapper(port=port_tests[port_test_index], threads=1, list_of_ips_file="ips.txt").run()
-        assert len(packet_list) == len(expected_ips) * len(expected_ports[port_test_index]), ("incorrect "
-                                                                                              "number of "
-                                                                                              "packets sent")
-        assert_expected_ips_and_ports_were_scanned(expected_ips, expected_port_set, packet_list)
-
-    # cleanup
-    os.remove("ips.txt")
-
-
 ## Shards
 def test_full_coverage_of_subnet_with_shards():
     """

--- a/test/integration-tests/test_dryrun_tcp.py
+++ b/test/integration-tests/test_dryrun_tcp.py
@@ -115,7 +115,7 @@ def test_multi_port_with_list_of_ips_option():
     """
     scan a list of random IPs with multiple ports and ensure all IP/port combinations are scanned
     """
-    port_tests = ["22-32,80"]
+    port_tests = ["22-24"]
     expected_ports = [utils.parse_ports_string(port_test) for port_test in port_tests]
     expected_ips = set(str(ip) for ip in utils.write_ips_to_file(10000, "ips.txt"))
 

--- a/test/integration-tests/utils.py
+++ b/test/integration-tests/utils.py
@@ -162,6 +162,14 @@ def bounded_runtime_test(t: zmap_wrapper.Wrapper):
 
 
 def write_ips_to_file(num_of_ips, filename):
+    """
+    Writes a list of public, non-blocked IPs to a file
+    Args:
+        num_of_ips (int): Number of IPs to write to the file
+        filename (str): File to write the IPs to
+    Returns:
+        List of IPs written to the file, as strings
+    """
     subnet_pattern = r'\b(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}\b'
     # read in blocked subnets in file "blocklist.conf" into a list
     blocked_subnets = []

--- a/test/integration-tests/utils.py
+++ b/test/integration-tests/utils.py
@@ -1,5 +1,7 @@
 import ipaddress
 import re
+
+from random import random
 from timeout_decorator import timeout
 import typing
 
@@ -159,3 +161,34 @@ def bounded_runtime_test(t: zmap_wrapper.Wrapper):
     return t.run()
 
 
+def write_ips_to_file(num_of_ips, filename):
+    subnet_pattern = r'\b(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}\b'
+    # read in blocked subnets in file "blocklist.conf" into a list
+    blocked_subnets = []
+    with open("../../conf/blocklist.conf", "r") as file:
+        for line in file:
+            if not line.startswith("#") and "/" in line:
+                # need to use a regex to pull out the subnet
+                subnet = re.findall(subnet_pattern, line.strip())
+                if subnet:
+                    blocked_subnets.append(subnet[0])
+
+    # generate a list of num_of_ips random, non-blocked public IPs
+    ips = []
+    for _ in range(num_of_ips):
+        while True:
+            ip = str(ipaddress.IPv4Address(int(2 ** 32 * random())))
+            # ensure the IP is not in the blocklist
+            if any(ipaddress.ip_address(ip) in ipaddress.ip_network(subnet) for subnet in blocked_subnets):
+                # IP is blocked
+                continue
+            if ipaddress.ip_address(ip).is_global and not ipaddress.ip_address(ip).is_reserved:
+                # found a good IP
+                ips.append(ip)
+                break
+    # write the IPs to a file
+    with open(filename, "w") as file:
+        for ip in ips:
+            file.write(ip + "\n")
+
+    return ips

--- a/test/integration-tests/utils.py
+++ b/test/integration-tests/utils.py
@@ -182,7 +182,7 @@ def write_ips_to_file(num_of_ips, filename):
                     blocked_subnets.append(subnet[0])
 
     # generate a list of num_of_ips random, non-blocked public IPs
-    ips = []
+    ips = set()
     for _ in range(num_of_ips):
         while True:
             ip = str(ipaddress.IPv4Address(int(2 ** 32 * random())))
@@ -190,9 +190,9 @@ def write_ips_to_file(num_of_ips, filename):
             if any(ipaddress.ip_address(ip) in ipaddress.ip_network(subnet) for subnet in blocked_subnets):
                 # IP is blocked
                 continue
-            if ipaddress.ip_address(ip).is_global and not ipaddress.ip_address(ip).is_reserved:
+            if ipaddress.ip_address(ip).is_global and not ipaddress.ip_address(ip).is_reserved and ip not in ips:
                 # found a good IP
-                ips.append(ip)
+                ips.add(ip)
                 break
     # write the IPs to a file
     with open(filename, "w") as file:


### PR DESCRIPTION
## Description
It seems that when #831 was opened, this was run before #825  that capped the percentage complete (this is why I have 3 tests, 1 for the code the issue opener used, one for `main` and one for post-fix). 

## Changes
Only real change is in `monitor.c` to factor in number of ports when calculating time remaining. Not considering this led to the percentage growing over 100%, ex: scanning 3 ports meant percentage complete would rise to 300%. I tried to make an integration test to test the `status_file` to make sure that the eta was non-increasing, the percentage complete was non-decreasing, etc. However, this can't be run with `--dryrun` and so the test was taking forever to run with `pytest`. Decided it wasn't necessary but refactored a bit in the `integration-tests` while I was there.

## Testing

Using `be2b` (prior to capping percentage complete). Note the crazy percentage complete, which matches what the issue opener saw.
```
$ sudo ./src/zmap -p 22-28 -w random_ips.txt -o /dev/null -r 10000 -c 1
...
 0:00 0%; send: 0 0 p/s (0 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 52%; send: 10371 10.4 Kp/s (9.78 Kp/s avg); recv: 26 26 p/s (24 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.25%
 0:02 102%; send: 20251 9.88 Kp/s (9.83 Kp/s avg); recv: 38 12 p/s (18 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.19%
 0:03 152%; send: 30249 10.00 Kp/s (9.88 Kp/s avg); recv: 38 0 p/s (12 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.13%
 0:04 202%; send: 40257 10.0 Kp/s (9.91 Kp/s avg); recv: 62 24 p/s (15 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.15%
 0:05 252% (136 years left); send: 50258 10.00 Kp/s (9.93 Kp/s avg); recv: 99 37 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:06 302% (136 years left); send: 60262 10.0 Kp/s (9.94 Kp/s avg); recv: 116 17 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.19%
 0:07 351% (136 years left); send: 69864 9.60 Kp/s (9.89 Kp/s avg); recv: 146 30 p/s (20 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.21%
 0:08 99% (1s left); send: 70000 done (9.84 Kp/s avg); recv: 166 20 p/s (20 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.24%
 
 Current HEAD of `main`. Notice the percent just sits at 100% which looking at the packets sent is not accurate at all
 ```
~/zmap-dev on  main! ⌚ 18:13:53
$ sudo ./src/zmap -p 22-28 -w random_ips.txt -o /dev/null -r 10000 -c 1
...
 0:00 0%; send: 0 0 p/s (0 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 53%; send: 10391 10.4 Kp/s (9.77 Kp/s avg); recv: 23 23 p/s (21 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.22%
 0:02 100%; send: 20392 10.00 Kp/s (9.88 Kp/s avg); recv: 46 23 p/s (22 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.23%
 0:03 100%; send: 30271 9.88 Kp/s (9.88 Kp/s avg); recv: 46 0 p/s (15 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.15%
 0:04 100%; send: 40271 10.00 Kp/s (9.91 Kp/s avg); recv: 63 17 p/s (15 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.16%
 0:05 100% (0s left); send: 50273 10.0 Kp/s (9.93 Kp/s avg); recv: 89 26 p/s (17 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.18%
 0:06 100% (0s left); send: 60272 10.00 Kp/s (9.94 Kp/s avg); recv: 120 31 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:07 100% (0s left); send: 69873 9.60 Kp/s (9.89 Kp/s avg); recv: 137 17 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:08 99% (1s left); send: 70000 done (9.84 Kp/s avg); recv: 163 26 p/s (20 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.23%
 0:09 100% (0s left); send: 70000 done (9.84 Kp/s avg); recv: 163 0 p/s (17 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.23%
```

Post-fix, looks accurate.
```
~/zmap-dev on  phillip/832! ⌚ 18:15:13
$ sudo ./src/zmap -p 22-28 -w random_ips.txt -o /dev/null -r 10000 -c 1
...
 0:00 0%; send: 0 0 p/s (0 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 13%; send: 10368 10.4 Kp/s (9.85 Kp/s avg); recv: 21 21 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:02 25%; send: 20370 10.0 Kp/s (9.92 Kp/s avg); recv: 32 11 p/s (15 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.16%
 0:03 38%; send: 30372 10.0 Kp/s (9.95 Kp/s avg); recv: 52 20 p/s (17 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.17%
 0:04 50%; send: 40375 10.0 Kp/s (9.96 Kp/s avg); recv: 79 27 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:05 63% (3s left); send: 50380 10.0 Kp/s (9.97 Kp/s avg); recv: 100 21 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.20%
 0:06 76% (2s left); send: 60381 10.00 Kp/s (9.97 Kp/s avg); recv: 126 26 p/s (20 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.21%
 0:07 88% (2s left); send: 69943 9.56 Kp/s (9.91 Kp/s avg); recv: 147 21 p/s (20 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.21%
 0:08 100% (1s left); send: 70000 done (9.89 Kp/s avg); recv: 160 13 p/s (19 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.23%
 0:09 100% (0s left); send: 70000 done (9.89 Kp/s avg); recv: 160 0 p/s (17 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.23%
```