### PR TITLE
Allow small scans without erroring

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -52,6 +52,16 @@ int min_int(int a, int b)
 	return a;
 }
 
+uint64_t min_uint64_t(uint64_t a, uint64_t b)
+{
+	if (a >= b) {
+		return b;
+	}
+	return a;
+}
+
+
+
 void enforce_range(const char *name, int v, int min, int max)
 {
 	if (check_range(v, min, max) == EXIT_FAILURE) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -25,6 +25,7 @@
 
 int max_int(int a, int b);
 int min_int(int a, int b);
+uint64_t min_uint64_t(uint64_t a, uint64_t b);
 
 uint32_t parse_max_hosts(char *max_targets);
 void enforce_range(const char *name, int v, int min, int max);

--- a/src/send.c
+++ b/src/send.c
@@ -67,9 +67,8 @@ iterator_t *send_init(void)
 {
 	// generate a new primitive root and starting position
 	iterator_t *it;
-	uint32_t num_subshards =
-	    (uint32_t)zconf.senders * (uint32_t)zconf.total_shards;
-	if (num_subshards > blocklist_count_allowed()) {
+	uint32_t num_subshards = (uint32_t)zconf.senders * (uint32_t)zconf.total_shards;
+	if (num_subshards > (blocklist_count_allowed() * zconf.ports->port_count)) {
 		log_fatal("send", "senders * shards > allowed probes");
 	}
 	if (zsend.max_targets && (num_subshards > zsend.max_targets)) {

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -1055,9 +1055,9 @@ int main(int argc, char *argv[])
 		if (available_cores > 1) {
 			available_cores--;
 		}
-		int senders = min_int(available_cores, 4);
+		int senders = (int) min_uint64_t(min_uint64_t(available_cores, 4), (zconf.total_allowed * zconf.ports->port_count));
 		zconf.senders = senders;
-		log_debug("zmap", "will use %i sender threads based on core availability", senders);
+		log_debug("zmap", "will use %i sender threads based on core availability and number of targets", senders);
 	}
 #ifdef NETMAP
 	if (zconf.senders > (int)zconf.nm.nm_if->ni_tx_rings) {


### PR DESCRIPTION
If you try to scan only a very small number of IPs, this will immediately error because the number of CPU cores is larger than the number of targets. This caps the number of threads at the number of targets scanned.