### PR TITLE
Use libpcap timestamp information instead of calling gettimeofday() in receive thread

### DIFF
--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -79,22 +79,20 @@ void fs_add_ip_fields(fieldset_t *fs, struct ip *ip)
 
 #define TIMESTR_LEN 55
 
-void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown)
+void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown, const struct timespec ts)
 {
 	fs_add_bool(fs, "repeat", is_repeat);
 	fs_add_bool(fs, "cooldown", in_cooldown);
 
 	char *timestr = xmalloc(TIMESTR_LEN + 1);
 	char *timestr_ms = xmalloc(TIMESTR_LEN + 1);
-	struct timeval t;
-	gettimeofday(&t, NULL);
-	struct tm *ptm = localtime(&t.tv_sec);
+	struct tm *ptm = localtime(&ts.tv_sec);
 	strftime(timestr, TIMESTR_LEN, "%Y-%m-%dT%H:%M:%S.%%03d%z", ptm);
-	snprintf(timestr_ms, TIMESTR_LEN, timestr, t.tv_usec / 1000);
+	snprintf(timestr_ms, TIMESTR_LEN, timestr, ts.tv_nsec / 1000000);
 	free(timestr);
 	fs_add_string(fs, "timestamp_str", timestr_ms, 1);
-	fs_add_uint64(fs, "timestamp_ts", (uint64_t)t.tv_sec);
-	fs_add_uint64(fs, "timestamp_us", (uint64_t)t.tv_usec);
+	fs_add_uint64(fs, "timestamp_ts", (uint64_t)ts.tv_sec);
+	fs_add_uint64(fs, "timestamp_us", (uint64_t)(ts.tv_nsec/1000));
 }
 
 int ip_fields_len = 6;

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -114,7 +114,7 @@ typedef struct probe_module {
 probe_module_t *get_probe_module_by_name(const char *);
 
 void fs_add_ip_fields(fieldset_t *fs, struct ip *ip);
-void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown);
+void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown, const struct timespec ts);
 void print_probe_modules(void);
 
 extern int ip_fields_len;

--- a/src/recv.c
+++ b/src/recv.c
@@ -112,7 +112,7 @@ void handle_packet(uint32_t buflen, const u_char *bytes,
 		buflen += sizeof(struct ether_header);
 	}
 	zconf.probe_module->process_packet(bytes, buflen, fs, validation, ts);
-	fs_add_system_fields(fs, is_repeat, zsend.complete);
+	fs_add_system_fields(fs, is_repeat, zsend.complete, ts);
 	int success_index = zconf.fsconf.success_index;
 	assert(success_index < fs->len);
 	int is_success = fs_get_uint64_by_index(fs, success_index);


### PR DESCRIPTION
For every packet that ZMap receives it calls `gettimeofday()` in the receive thread to write the receive time to the output file. Instead, the already present timestamp in the PCAP header can be used which should save CPU cycles and lead to more accurate receive times.