### PR TITLE
Increase sending slow_rate threshold to 200 

### DIFF
--- a/src/send.c
+++ b/src/send.c
@@ -254,7 +254,7 @@ int send_run(sock_t st, shard_t *s)
 	double send_rate =
 	    (double)zconf.rate /
 	    ((double)zconf.senders * zconf.packet_streams);
-	const double slow_rate = 500; // packets per seconds per thread
+	const double slow_rate = 1000; // packets per seconds per thread
 	// at which it uses the slow methods
 	long nsec_per_sec = 1000 * 1000 * 1000;
 	long long sleep_time = nsec_per_sec;

--- a/src/send.c
+++ b/src/send.c
@@ -254,7 +254,7 @@ int send_run(sock_t st, shard_t *s)
 	double send_rate =
 	    (double)zconf.rate /
 	    ((double)zconf.senders * zconf.packet_streams);
-	const double slow_rate = 50; // packets per seconds per thread
+	const double slow_rate = 200; // packets per seconds per thread
 	// at which it uses the slow methods
 	long nsec_per_sec = 1000 * 1000 * 1000;
 	long long sleep_time = nsec_per_sec;

--- a/src/send.c
+++ b/src/send.c
@@ -254,7 +254,7 @@ int send_run(sock_t st, shard_t *s)
 	double send_rate =
 	    (double)zconf.rate /
 	    ((double)zconf.senders * zconf.packet_streams);
-	const double slow_rate = 200; // packets per seconds per thread
+	const double slow_rate = 500; // packets per seconds per thread
 	// at which it uses the slow methods
 	long nsec_per_sec = 1000 * 1000 * 1000;
 	long long sleep_time = nsec_per_sec;


### PR DESCRIPTION
Thanks for maintaining the awesome ZMap.
I'd like to perform scans with a rate of 100pps. I've observed that ZMap consumes a lot of CPU in that case. However, if I increase the slow rate threshold in send.c (to maybe 200), everything is fine - would you like to merge this to main? 

Of course, don't merge if there is a profound reason of '50' being the current threshold.