### PR TITLE
Fixed bug that led to inaccurate max_packet_length based on TCP Options

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -36,7 +36,6 @@ static int synscan_global_initialize(struct state_conf *state)
 {
 	num_source_ports =
 	    state->source_port_last - state->source_port_first + 1;
-	module_tcp_synscan.max_packet_length = zmap_tcp_synscan_packet_len;
 	// Based on the OS, we'll set the TCP options differently
 	if (!state->probe_args) {
 		// user didn't provide any probe args, defaulting to linux
@@ -68,6 +67,8 @@ static int synscan_global_initialize(struct state_conf *state)
 					 "\"windows\", and \"linux\"",
 			  state->probe_args);
 	}
+	// set max packet length accordingly for accurate send rate calculation
+	module_tcp_synscan.max_packet_length = zmap_tcp_synscan_packet_len;
 	// double-check arithmetic
 	assert(zmap_tcp_synscan_packet_len - zmap_tcp_synscan_tcp_header_len == 34);
 


### PR DESCRIPTION
The module's `max_packet_length` is used for accurately computing the send rate to stay under any user-given bandwidth limitations. 

This bug meant that the packet length was only accurate for the case where no TCP options were used (`--probe-args="none"`) and incorrect for all other options.

## Testing
Before fix, `--probe-args="windows" -B 1G` and `--probe-args="linux" -B 1G` would give the same send rate on a non-bandwidth constrained system, even though `windows` sends 8 bytes less per probe packet.

After fix, the same test results in `1.34 Mpps` for `windows` and `1.24 Mpps` for `linux`.