### PR TITLE
Change default TCP options for SYNSCAN module to Windows-style and add "smallest-probes" option

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -40,11 +40,11 @@ static int synscan_global_initialize(struct state_conf *state)
 	if (!state->probe_args) {
 		// user didn't provide any probe args, defaulting to windows
 		log_debug("tcp_synscan", "no probe-args, "
-					 "defaulting to Windows TCP options. Windows-style TCP options offer the highest hit-rate with the least bytes per probe.");
+					 "defaulting to Windows-style TCP options. Windows-style TCP options offer the highest hit-rate with the least bytes per probe.");
 		state->probe_args = (char *)"windows";
 	}
 	if (strcmp(state->probe_args, "smallest-probes") == 0) {
-		os_for_tcp_options = SMALLEST_ETHERNET_OS_OPTIONS;
+		os_for_tcp_options = SMALLEST_PROBES_OS_OPTIONS;
 		zmap_tcp_synscan_tcp_header_len = 24;
 		zmap_tcp_synscan_packet_len = 58;
 	} else if (strcmp(state->probe_args, "bsd") == 0) {

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -45,8 +45,8 @@ static int synscan_global_initialize(struct state_conf *state)
 	}
 	if (strcmp(state->probe_args, "smallest-probes") == 0) {
 		os_for_tcp_options = SMALLEST_ETHERNET_OS_OPTIONS;
-		zmap_tcp_synscan_tcp_header_len = 20;
-		zmap_tcp_synscan_packet_len = 54;
+		zmap_tcp_synscan_tcp_header_len = 24;
+		zmap_tcp_synscan_packet_len = 58;
 	} else if (strcmp(state->probe_args, "bsd") == 0) {
 		os_for_tcp_options = BSD_OS_OPTIONS;
 		zmap_tcp_synscan_tcp_header_len = 44;
@@ -273,8 +273,8 @@ probe_module_t module_tcp_synscan = {
 	"By default, TCP header options are set identically to the values used by "
 	"Windows (MSS, SACK permitted, and WindowScale = 8). Use \"--probe-args=n\" "
 	"to set the options, valid options are "
-	"\"smallest-possible\", \"bsd\", \"linux\", \"windows\" (default). "
-	"The \"smallest-possible\" option only sends MSS to achieve a better hit-rate "
+	"\"smallest-probes\", \"bsd\", \"linux\", \"windows\" (default). "
+	"The \"smallest-probes\" option only sends MSS to achieve a better hit-rate "
 	"than no options while staying within the minimum Ethernet payload size. Windows-style "
 	"TCP options offer the highest hit-rate with a modest increase in probe size.",
     .output_type = OUTPUT_TYPE_STATIC,

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -38,13 +38,13 @@ static int synscan_global_initialize(struct state_conf *state)
 	    state->source_port_last - state->source_port_first + 1;
 	// Based on the OS, we'll set the TCP options differently
 	if (!state->probe_args) {
-		// user didn't provide any probe args, defaulting to linux
+		// user didn't provide any probe args, defaulting to windows
 		log_debug("tcp_synscan", "no probe-args, "
-					 "defaulting to linux TCP options");
-		state->probe_args = (char *)"linux";
+					 "defaulting to Windows TCP options. Windows-style TCP options offer the highest hit-rate with the least bytes per probe.");
+		state->probe_args = (char *)"windows";
 	}
-	if (strcmp(state->probe_args, "none") == 0) {
-		os_for_tcp_options = NO_OPTIONS;
+	if (strcmp(state->probe_args, "smallest-probes") == 0) {
+		os_for_tcp_options = SMALLEST_ETHERNET_OS_OPTIONS;
 		zmap_tcp_synscan_tcp_header_len = 20;
 		zmap_tcp_synscan_packet_len = 54;
 	} else if (strcmp(state->probe_args, "bsd") == 0) {
@@ -270,10 +270,13 @@ probe_module_t module_tcp_synscan = {
 	"Probe module that sends a TCP SYN packet to a specific port. Possible "
 	"classifications are: synack and rst. A SYN-ACK packet is considered a "
 	"success and a reset packet is considered a failed response. "
-	"By default, TCP header options are set identically to the values for "
-	"linux (Ubuntu 23.10) (MSS, SACK permitted, Timestamp,  and WindowScale "
-	"= 7). Use \"--probe-args=n\" to set the options, valid options are "
-	"\"none\", \"bsd\", \"windows\", \"linux\" (default).",
+	"By default, TCP header options are set identically to the values used by "
+	"Windows (MSS, SACK permitted, and WindowScale = 8). Use \"--probe-args=n\" "
+	"to set the options, valid options are "
+	"\"smallest-possible\", \"bsd\", \"linux\", \"windows\" (default). "
+	"The \"smallest-possible\" option only sends MSS to achieve a better hit-rate "
+	"than no options while staying within the minimum Ethernet payload size. Windows-style "
+	"TCP options offer the highest hit-rate with a modest increase in probe size.",
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
     .numfields = sizeof(fields) / sizeof(fields[0])};

--- a/src/probe_modules/module_tcp_synscan.h
+++ b/src/probe_modules/module_tcp_synscan.h
@@ -20,7 +20,7 @@
 #include "probe_modules.h"
 #include "packet.h"
 
-#define NO_OPTIONS 0x00
+#define SMALLEST_ETHERNET_OS_OPTIONS 0x00
 #define LINUX_OS_OPTIONS 0x01
 #define BSD_OS_OPTIONS 0x02
 #define WINDOWS_OS_OPTIONS 0x03

--- a/src/probe_modules/module_tcp_synscan.h
+++ b/src/probe_modules/module_tcp_synscan.h
@@ -20,7 +20,7 @@
 #include "probe_modules.h"
 #include "packet.h"
 
-#define SMALLEST_ETHERNET_OS_OPTIONS 0x00
+#define SMALLEST_PROBES_OS_OPTIONS 0x00
 #define LINUX_OS_OPTIONS 0x01
 #define BSD_OS_OPTIONS 0x02
 #define WINDOWS_OS_OPTIONS 0x03

--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -240,7 +240,7 @@ size_t set_sack_permitted_plus_eol(struct tcphdr *tcp_header)
 // set_tcp_options adds the relevant TCP options so ZMap-sent packets have the same TCP header as linux-sent ones
 size_t set_tcp_options(struct tcphdr *tcp_header, uint8_t os_options_type)
 {
-	if (os_options_type == SMALLEST_ETHERNET_OS_OPTIONS) {
+	if (os_options_type == SMALLEST_PROBES_OS_OPTIONS) {
 		// the minimum Ethernet payload is 46 bytes. A TCP header + IP header is 40 bytes, giving us 6 bytes to work with.
 		// However, the word size is 4 bytes, so we can only use 44 or 48 bytes. Since we're trying to stay as close to the
 		// minimum payload size, we'll use 4 bytes for the MSS option and the last 2 will be padded by the OS.

--- a/src/probe_modules/packet.c
+++ b/src/probe_modules/packet.c
@@ -240,8 +240,11 @@ size_t set_sack_permitted_plus_eol(struct tcphdr *tcp_header)
 // set_tcp_options adds the relevant TCP options so ZMap-sent packets have the same TCP header as linux-sent ones
 size_t set_tcp_options(struct tcphdr *tcp_header, uint8_t os_options_type)
 {
-	if (os_options_type == NO_OPTIONS) {
-		// nothing to set
+	if (os_options_type == SMALLEST_ETHERNET_OS_OPTIONS) {
+		// the minimum Ethernet payload is 46 bytes. A TCP header + IP header is 40 bytes, giving us 6 bytes to work with.
+		// However, the word size is 4 bytes, so we can only use 44 or 48 bytes. Since we're trying to stay as close to the
+		// minimum payload size, we'll use 4 bytes for the MSS option and the last 2 will be padded by the OS.
+		set_mss_option(tcp_header);
 	} else if (os_options_type == LINUX_OS_OPTIONS) {
 		set_mss_option(tcp_header);
 		set_sack_permitted_with_timestamp(tcp_header);


### PR DESCRIPTION
After some investigation, I realized that the hit-rates ZMap sees vary depending on TCP options. Sending options exactly as the major OS's send offers a consistent, measurable improvement in hit-rate. Of these, Windows-style packets are the smallest by 8 bytes.

I ran 3 trials over 10% of the IPv4 space and found median hit rates on port 80:

|                   TCP Options Style|            Hit-rate    |  Size of Packet   |Max. Packets-per-Second (millions)|
|---|---|---|---|
|No TCP options |1.305%.    |     46            |                1.488|
|Windows |  1.331%       |    52                     |      1.389|
|smallest-probes| 1.328%   |       46            |                1.488|
|Linux-style.        |1.330%.    |    60              |              1.276|

Based on this, I think using a default of `windows` would offer the best accuracy with least impact on performance. `smallest-probes` is added in case a small penalty to accuracy is acceptable to chase the highest performance. The reason both `smallest-probes` (using MSS) and `no options` are the same size is that the minimum Ethernet payload is 46 bytes, so anything smaller is just padded.

## Testing
Confirmed with `tcpdump` that the default behavior is using `windows` and `smallest-probes` is only sending MSS.
 