### PR TITLE
UDP module: Add hex string and unix timestamp values to template

### DIFF
--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -34,7 +34,10 @@ typedef enum udp_payload_field_type {
 	UDP_RAND_BYTE,
 	UDP_RAND_DIGIT,
 	UDP_RAND_ALPHA,
-	UDP_RAND_ALPHANUM
+	UDP_RAND_ALPHANUM,
+	UDP_HEX,
+	UDP_UNIXTIME_SEC,
+	UDP_UNIXTIME_USEC
 } udp_payload_field_type_t;
 
 typedef struct udp_payload_field_type_def {


### PR DESCRIPTION
This allows to add the following three payload field types to the UDP templating feature:

* `HEX`: String of hex-encoded byte values
* `UNIXTIME_SEC`: Time in seconds since the Unix epoch in network byte order
* `UNIXTIME_USEC`: Microsecond part of Unix time in network byte order