### PR TITLE
Fix unknown probe-args guidance for none -> smallest-probes change

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -63,7 +63,7 @@ static int synscan_global_initialize(struct state_conf *state)
 		log_fatal("tcp_synscan", "unknown "
 					 "probe-args value: %s, probe-args "
 					 "should have format: \"--probe-args=os\" "
-					 "where os can be \"none\", \"bsd\", "
+					 "where os can be \"smallest-probes\", \"bsd\", "
 					 "\"windows\", and \"linux\"",
 			  state->probe_args);
 	}


### PR DESCRIPTION
Update guidance in error message to list `smallest-probes` instead of `none` which no longer exists.

#855 changed `--probe-args=none` to `--probe-args=smallest-probes`, but the error message for unknown `--probe-args` arguments still lists `none` as a valid argument (which is especially confusing when using `--probe-args=none` results in guidance suggesting to use `none`).