### PR TITLE
Use less memory for constraint lookup radix cache

### DIFF
--- a/lib/constraint.c
+++ b/lib/constraint.c
@@ -72,7 +72,7 @@ typedef struct node {
 
 // As an optimization, we precompute lookups for every prefix of this
 // length:
-#define RADIX_LENGTH 20
+#define RADIX_LENGTH 18
 
 struct _constraint {
 	node_t *root;	     // root node of the tree


### PR DESCRIPTION
Reduce the size of the precomputed array of prefixes from 4 MB to 1 MB in order to fit into the cache of CPUs with lower amounts of cache.  Improves send rate on systems where send rate is CPU/memory-bound and cache is limited.

With the default blocklist, this changes the array/tree tradeoff from 3702243328 IPs in radix array, 15104 IPs in tree to 3702194176 IPs in radix array, 64256 IPs in tree.  That _seems_ like a reasonable price to pay for the perf boost of reducing the memory footprint to one fourth.  On a system with 8 core Intel Atom, 8*2 MB L2 cache, 10 GbE NIC, netmap, AES-NI, before this change, send rate was 11% below what the NIC can do, while with this change, zmap pushes packets faster than the NIC can send them.  You may want to test this change on higher end systems before merging, to assert that it does not perform substantially worse on different system configurations.