### PR TITLE
Fix integration-tests Dockerfile, add new Ubuntu 24.04 compilation test

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,6 +77,16 @@ jobs:
           docker build -t ubuntu-22.04-container -f .github/workflows/ubuntu-22.04.Dockerfile .
           docker run ubuntu-22.04-container
 
+  build-ubuntu-24-04:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Compilation
+        run: |
+          docker build -t ubuntu-24.04-container -f .github/workflows/ubuntu-24.04.Dockerfile .
+          docker run ubuntu-24.04-container
+
   build-debian:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pytest.Dockerfile
+++ b/.github/workflows/pytest.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:latest
 
 RUN apt-get update
 RUN apt-get install -y build-essential cmake libgmp3-dev gengetopt libpcap-dev flex \

--- a/.github/workflows/pytest.Dockerfile
+++ b/.github/workflows/pytest.Dockerfile
@@ -1,11 +1,9 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
-RUN apt-get update \
-    && apt-get install -y build-essential cmake libgmp3-dev gengetopt libpcap-dev flex \
-    byacc libjson-c-dev pkg-config libunistring-dev libjudy-dev cmake  make python3 python3-pip curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-RUN pip3 install pytest timeout-decorator
+RUN apt-get update
+RUN apt-get install -y build-essential cmake libgmp3-dev gengetopt libpcap-dev flex \
+    byacc libjson-c-dev pkg-config libunistring-dev libjudy-dev cmake  make python3 python3-pytest python3-timeout-decorator curl
+RUN apt-get clean
 
 
 WORKDIR /zmap

--- a/.github/workflows/ubuntu-24.04.Dockerfile
+++ b/.github/workflows/ubuntu-24.04.Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+# Set non-interactive mode so that apt-get does not prompt for input
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y build-essential cmake libgmp3-dev gengetopt libpcap-dev flex \
+    byacc libjson-c-dev pkg-config libunistring-dev libjudy-dev cmake  make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+
+WORKDIR /zmap
+COPY . .
+
+RUN cmake -DENABLE_DEVELOPMENT=$ENABLE_DEVELOPMENT -DENABLE_LOG_TRACE=$ENABLE_LOG_TRACE . \
+    && make


### PR DESCRIPTION
With the release of Ubuntu 24.04, the way python wants you to install dependencies system-wide changed. The Dockerfile specified `ubuntu:latest` so we ran into this.

## Fix

- Import python packages with `apt-get install python3-pytest` to install them system-wide
- Add new `ubuntu-24.04` test just for compilation for the new OS