### PR TITLE
Decreased pcap_timeout to prevent monitor timing issue

### DIFF
--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -30,7 +30,7 @@
 #include "probe_modules/probe_modules.h"
 
 #define PCAP_PROMISC 1
-#define PCAP_TIMEOUT 1000
+#define PCAP_TIMEOUT 100
 
 static pcap_t *pc = NULL;
 


### PR DESCRIPTION
More details in PR, closes #852 .

## Description
Before, there was a timing issue since the monitor thread could run twice in between two receive thread runs. By reducing this timeout on the receive thread, this should prevent that from happening. 

## Test
Ran a scan and no longer see 0 p/s at line 43.
```
 0:00 0%; send: 0 0 p/s (0 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 2%; send: 10394 10.4 Kp/s (9.99 Kp/s avg); recv: 125 125 p/s (120 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.20%
 0:02 4%; send: 20394 10.00 Kp/s (9.99 Kp/s avg); recv: 250 125 p/s (122 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.23%
 0:03 6%; send: 30400 10.0 Kp/s (9.99 Kp/s avg); recv: 377 127 p/s (123 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.24%
 0:04 8%; send: 40151 9.75 Kp/s (9.93 Kp/s avg); recv: 494 117 p/s (122 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.23%
 0:05 10% (46s left); send: 50154 10.0 Kp/s (9.95 Kp/s avg); recv: 632 138 p/s (125 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.26%
 0:06 12% (45s left); send: 60031 9.88 Kp/s (9.94 Kp/s avg); recv: 779 147 p/s (128 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:07 14% (44s left); send: 70034 10.0 Kp/s (9.94 Kp/s avg); recv: 911 132 p/s (129 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:08 16% (43s left); send: 80035 10.00 Kp/s (9.95 Kp/s avg); recv: 1051 140 p/s (130 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
 0:09 18% (42s left); send: 90037 10.0 Kp/s (9.96 Kp/s avg); recv: 1174 123 p/s (129 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:10 20% (41s left); send: 100039 10.0 Kp/s (9.96 Kp/s avg); recv: 1308 134 p/s (130 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
 0:11 22% (40s left); send: 110042 10.0 Kp/s (9.96 Kp/s avg); recv: 1456 148 p/s (131 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.32%
 0:12 24% (39s left); send: 120042 10.00 Kp/s (9.97 Kp/s avg); recv: 1599 143 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:13 26% (38s left); send: 130045 10.0 Kp/s (9.97 Kp/s avg); recv: 1728 129 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:14 28% (37s left); send: 140049 10.0 Kp/s (9.97 Kp/s avg); recv: 1849 121 p/s (131 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.32%
 0:15 29% (36s left); send: 150049 10.00 Kp/s (9.97 Kp/s avg); recv: 1978 129 p/s (131 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.32%
 0:16 31% (35s left); send: 160054 10.0 Kp/s (9.97 Kp/s avg); recv: 2144 166 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:17 33% (34s left); send: 170055 10.00 Kp/s (9.98 Kp/s avg); recv: 2278 134 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:18 35% (33s left); send: 180058 10.0 Kp/s (9.98 Kp/s avg); recv: 2416 138 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:19 37% (32s left); send: 190059 10.00 Kp/s (9.98 Kp/s avg); recv: 2561 145 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:20 39% (31s left); send: 200062 10.0 Kp/s (9.98 Kp/s avg); recv: 2693 132 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:21 41% (30s left); send: 210063 10.00 Kp/s (9.98 Kp/s avg); recv: 2832 139 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:22 43% (29s left); send: 220066 10.0 Kp/s (9.98 Kp/s avg); recv: 2959 127 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:23 45% (28s left); send: 229941 9.87 Kp/s (9.98 Kp/s avg); recv: 3088 129 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:24 47% (27s left); send: 239944 10.0 Kp/s (9.98 Kp/s avg); recv: 3238 150 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:25 49% (26s left); send: 249947 10.0 Kp/s (9.98 Kp/s avg); recv: 3374 136 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:26 51% (25s left); send: 259949 10.0 Kp/s (9.98 Kp/s avg); recv: 3513 139 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:27 53% (24s left); send: 269953 10.0 Kp/s (9.98 Kp/s avg); recv: 3640 127 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:28 55% (23s left); send: 279954 10.00 Kp/s (9.98 Kp/s avg); recv: 3753 113 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:29 57% (22s left); send: 289957 10.0 Kp/s (9.98 Kp/s avg); recv: 3913 160 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:30 59% (21s left); send: 299957 10.00 Kp/s (9.98 Kp/s avg); recv: 4040 127 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:31 61% (20s left); send: 309836 9.88 Kp/s (9.98 Kp/s avg); recv: 4170 130 p/s (134 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.35%
 0:32 63% (19s left); send: 319839 10.0 Kp/s (9.98 Kp/s avg); recv: 4292 122 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:33 65% (18s left); send: 329837 10.00 Kp/s (9.98 Kp/s avg); recv: 4427 135 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:34 67% (17s left); send: 339843 10.0 Kp/s (9.98 Kp/s avg); recv: 4549 122 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:35 69% (16s left); send: 349844 10.00 Kp/s (9.98 Kp/s avg); recv: 4680 131 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:36 71% (15s left); send: 359846 10.0 Kp/s (9.98 Kp/s avg); recv: 4811 131 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:37 73% (14s left); send: 369847 10.00 Kp/s (9.98 Kp/s avg); recv: 4955 144 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:38 75% (13s left); send: 379851 10.0 Kp/s (9.98 Kp/s avg); recv: 5071 116 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:39 77% (12s left); send: 389726 9.87 Kp/s (9.98 Kp/s avg); recv: 5201 130 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:40 79% (11s left); send: 399730 10.0 Kp/s (9.98 Kp/s avg); recv: 5326 125 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:41 80% (10s left); send: 409730 10.00 Kp/s (9.98 Kp/s avg); recv: 5447 121 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:42 82% (9s left); send: 419735 10.0 Kp/s (9.98 Kp/s avg); recv: 5585 138 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:43 84% (8s left); send: 429737 10.0 Kp/s (9.98 Kp/s avg); recv: 5711 126 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:44 86% (7s left); send: 439739 10.0 Kp/s (9.98 Kp/s avg); recv: 5846 135 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:45 88% (6s left); send: 449742 10.0 Kp/s (9.98 Kp/s avg); recv: 5986 140 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:46 90% (5s left); send: 459745 10.0 Kp/s (9.98 Kp/s avg); recv: 6115 129 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:47 92% (4s left); send: 469747 10.0 Kp/s (9.98 Kp/s avg); recv: 6258 143 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:48 94% (3s left); send: 479750 10.0 Kp/s (9.98 Kp/s avg); recv: 6389 131 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:49 96% (2s left); send: 489753 10.0 Kp/s (9.98 Kp/s avg); recv: 6511 122 p/s (132 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
 0:50 98% (1s left); send: 499238 done (9.98 Kp/s avg); recv: 6669 158 p/s (133 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
 0:51 100% (0s left); send: 499238 done (9.98 Kp/s avg); recv: 6685 16 p/s (130 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
```