### PR TITLE
Have monitor thread calculate hitrate using unique success packets, not filtered success packets

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -191,7 +191,7 @@ static void export_stats(int_status_t *intrnl, export_status_t *exp,
 	uint64_t total_iterations = iterator_get_iterations(it);
 	uint32_t total_fail = iterator_get_fail(it);
 	uint64_t total_recv = zrecv.pcap_recv;
-	uint64_t recv_success = zrecv.filter_success;
+	uint64_t recv_success = zrecv.success_unique;
 	uint32_t app_success = zrecv.app_success_unique;
 	double cur_time = now();
 	double age = cur_time - zsend.start; // time of entire scan


### PR DESCRIPTION
Closes #863 

Used `git bisect` to find this bug, looks like it's been in the code since 2021. (introduced in commit `a66169`).

We want to calculate hit-rate using the de-duplicated success packets. By using `filter_success`, the default behavior is to not de-duplicate responses. This led to the wild hit-rates.

## Testing
`main`
```
$ cmake . && make -j4 && sudo ./src/zmap -p 80 -n 1000000 -B 100M -o /dev/null -c 5 -i enp0s8 --output-fields="*"
...
 0:13 100% (0s left); send: 1000000 done (137 Kp/s avg); recv: 39246 0 p/s (3.01 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 3.92%
```

`Phillip/863` (with fix)
```
$ cmake . && make -j4 && sudo ./src/zmap -p 80 -n 1000000 -B 100M -o /dev/null -c 5 -i enp0s8 --output-fields="*"
...
 0:13 100% (0s left); send: 1000000 done (136 Kp/s avg); recv: 13290 0 p/s (1.02 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.33%
```

`v2.1.1` (old behavior)
```
$ cmake . && make -j4 && sudo ./src/zmap -p 80 -n 1000000 -B 100M -o /dev/null -c 5 -i enp0s8 --output-fields="*"
...
 0:11 94% (1s left); send: 1000000 done (149 Kp/s avg); recv: 13437 0 p/s (1.22 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.34%
```