### PR TITLE
Revert "Decreased pcap_timeout to prevent monitor issue ..."

### DIFF
--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -30,7 +30,7 @@
 #include "probe_modules/probe_modules.h"
 
 #define PCAP_PROMISC 1
-#define PCAP_TIMEOUT 100
+#define PCAP_TIMEOUT 1000
 
 static pcap_t *pc = NULL;
 


### PR DESCRIPTION
This reverts commit 957010f017c023030b41f14d56b535cd9c998062.

It looks like this caused #868, reverting this until I can find a fix to satisfy both this and #852 