### PR TITLE
Fix the dropping packets in the receive thread (actually this time)

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -14,7 +14,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <assert.h>
-#include <math.h>
 
 #include "../../lib/includes.h"
 #include "../../lib/logger.h"
@@ -208,65 +207,6 @@ static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 	return PACKET_VALID;
 }
 
-
-static void add_tcpopt_to_fs(fieldset_t *fs, int64_t *val, const char *label)
-{
-	if (*val != -1) {
-		fs_add_uint64(fs, label, *((uint64_t *) val));
-	} else {
-		fs_add_null(fs, label);
-	}
-}
-
-static void parse_tcp_opts(struct tcphdr *tcp, fieldset_t *fs)
-{
-	int64_t mss = -1, wscale = -1, sack_perm = -1, ts_val = -1, ts_ecr = -1;
-
-	size_t header_size = tcp->th_off * 4;
-	for (size_t curr_idx = 20; curr_idx < header_size; ) {
-		uint8_t *kind = ((uint8_t *) tcp) + curr_idx;
-		uint8_t *len = ((uint8_t *) tcp) + curr_idx + 1;
-		uint8_t *val = ((uint8_t *) tcp) + curr_idx + 2;
-
-		switch(*kind) {
-			case TCPOPT_EOL: // End of option list
-			case TCPOPT_NOP: // NOP
-				// EOL and NOP are 1 byte in length without any length or value fields
-				curr_idx += 1;
-				continue;
-
-			case TCPOPT_MAXSEG: // MSS
-				mss = ntohs(*(uint16_t *) val);
-				break;
-
-			case TCPOPT_WINDOW: // Window scale
-				wscale = pow(2, *((uint8_t *) val));
-				break;
-
-			case TCPOPT_SACK_PERMITTED: // SACK permitted
-				sack_perm = 1;
-				break;
-
-			case TCPOPT_TIMESTAMP: // TCP Timestamp
-				// Retrieve TS value and TS echo reply
-				ts_val = ntohl(*(uint32_t *) val);
-				ts_ecr = ntohl(*((uint32_t *) (val + 4)));
-				break;
-
-			default:
-				break;
-		}
-
-		curr_idx += *len;
-	}
-
-	add_tcpopt_to_fs(fs, &mss, "tcpopt_mss");
-	add_tcpopt_to_fs(fs, &wscale, "tcpopt_wscale");
-	add_tcpopt_to_fs(fs, &sack_perm, "tcpopt_sack_perm");
-	add_tcpopt_to_fs(fs, &ts_val, "tcpopt_ts_val");
-	add_tcpopt_to_fs(fs, &ts_ecr, "tcpopt_ts_ecr");
-}
-
 static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 				   fieldset_t *fs, UNUSED uint32_t *validation,
 				   UNUSED struct timespec ts)
@@ -281,7 +221,6 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		fs_add_uint64(fs, "seqnum", (uint64_t)ntohl(tcp->th_seq));
 		fs_add_uint64(fs, "acknum", (uint64_t)ntohl(tcp->th_ack));
 		fs_add_uint64(fs, "window", (uint64_t)ntohs(tcp->th_win));
-		parse_tcp_opts(tcp, fs);
 		if (tcp->th_flags & TH_RST) { // RST packet
 			fs_add_constchar(fs, "classification", "rst");
 			fs_add_bool(fs, "success", 0);
@@ -297,11 +236,6 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		fs_add_null(fs, "seqnum");
 		fs_add_null(fs, "acknum");
 		fs_add_null(fs, "window");
-		fs_add_null(fs, "tcpopt_mss");
-		fs_add_null(fs, "tcpopt_wscale");
-		fs_add_null(fs, "tcpopt_sack_perm");
-		fs_add_null(fs, "tcpopt_ts_val");
-		fs_add_null(fs, "tcpopt_ts_ecr");
 		// global
 		fs_add_constchar(fs, "classification", "icmp");
 		fs_add_bool(fs, "success", 0);
@@ -316,11 +250,6 @@ static fielddef_t fields[] = {
     {.name = "seqnum", .type = "int", .desc = "TCP sequence number"},
     {.name = "acknum", .type = "int", .desc = "TCP acknowledgement number"},
     {.name = "window", .type = "int", .desc = "TCP window"},
-    {.name = "tcpopt_mss", .type = "int", .desc = "TCP MSS option"},
-    {.name = "tcpopt_wscale", .type = "int", .desc = "TCP Window scale option"},
-    {.name = "tcpopt_sack_perm", .type = "int", .desc = "TCP SACK permitted option"},
-    {.name = "tcpopt_ts_val", .type = "int", .desc = "TCP timestamp option value"},
-    {.name = "tcpopt_ts_ecr", .type = "int", .desc = "TCP timestamp option echo reply"},
     CLASSIFICATION_SUCCESS_FIELDSET_FIELDS,
     ICMP_FIELDSET_FIELDS,
 };

--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -30,7 +30,7 @@
 #include "probe_modules/probe_modules.h"
 
 #define PCAP_PROMISC 1
-#define PCAP_TIMEOUT 1000
+#define PCAP_TIMEOUT 100
 
 static pcap_t *pc = NULL;
 


### PR DESCRIPTION
Closes #868 

I was re-testing this morning and realized even with #869 I was still seeing
`May 01 23:04:18.146 [WARN] monitor: Dropped 58542 packets in the last second, (58554 total dropped (pcap: 58554 + iface: 0))`

So reverting the PR that decreased the timeout on `pcap` wasn't the fix (should have caught that yesterday, I was too quick to assume and didn't validate sufficiently).
It seems the PR right after (#858 ), where we added TCP options parsing to the `synscan_process_packet` was the real culprit. Upon reverting that, everything works.

I will open an Issue to re-add TCP options parsing, might be some small tweaks we can do to that PR to speed it up so the callback can run fast enough to not bog down the receive thread.


## Testing
### Scan with current `main` (with `pcap` timeout reverted):
```
 0:00 0%; send: 93 1 p/s (5.91 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 2%; send: 3041530 3.04 Mp/s (2.99 Mp/s avg); recv: 34374 34.4 Kp/s (33.8 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.13%
 0:02 3%; send: 5720378 2.68 Mp/s (2.84 Mp/s avg); recv: 70396 36.0 Kp/s (34.9 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.23%
 0:03 5%; send: 8304058 2.58 Mp/s (2.75 Mp/s avg); recv: 104457 34.1 Kp/s (34.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.26%
 0:04 7%; send: 10790906 2.49 Mp/s (2.69 Mp/s avg); recv: 137604 33.1 Kp/s (34.3 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.28%
May 02 18:06:51.079 [WARN] monitor: Dropped 10847 packets in the last second, (10849 total dropped (pcap: 10849 + iface: 0))
 0:05 8% (56s left); send: 13204011 2.41 Mp/s (2.63 Mp/s avg); recv: 163004 25.4 Kp/s (32.5 Kp/s avg); drops: 10.8 Kp/s (2.16 Kp/s avg); hitrate: 1.23%
May 02 18:06:52.080 [WARN] monitor: Dropped 108676 packets in the last second, (119553 total dropped (pcap: 119553 + iface: 0))
 0:06 10% (55s left); send: 15609658 2.41 Mp/s (2.59 Mp/s avg); recv: 163004 0 p/s (27.1 Kp/s avg); drops: 109 Kp/s (19.9 Kp/s avg); hitrate: 1.04%
May 02 18:06:53.080 [WARN] monitor: Dropped 108048 packets in the last second, (227630 total dropped (pcap: 227630 + iface: 0))
 0:07 12% (54s left); send: 17982778 2.37 Mp/s (2.56 Mp/s avg); recv: 163004 0 p/s (23.2 Kp/s avg); drops: 108 Kp/s (32.4 Kp/s avg); hitrate: 0.91%
********May 02 18:06:54.080 [WARN] monitor: Dropped 109055 packets in the last second, (336708 total dropped (pcap: 336708 + iface: 0))
 0:08 13% (53s left); send: 20397849 2.41 Mp/s (2.54 Mp/s avg); recv: 163004 0 p/s (20.3 Kp/s avg); drops: 109 Kp/s (42.0 Kp/s avg); hitrate: 0.80%
********May 02 18:06:55.080 [WARN] monitor: Dropped 109878 packets in the last second, (446610 total dropped (pcap: 446610 + iface: 0))
 0:09 15% (52s left); send: 22852420 2.45 Mp/s (2.53 Mp/s avg); recv: 163004 0 p/s (18.1 Kp/s avg); drops: 110 Kp/s (49.5 Kp/s avg); hitrate: 0.71%
^C

~/zmap-dev on  main! ⌚ 18:06:55
```

### Scan with this PR fix in
```shell
 0:00 0%; send: 63 1 p/s (1.76 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
 0:01 2%; send: 2862010 2.86 Mp/s (2.76 Mp/s avg); recv: 32361 32.4 Kp/s (31.2 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.13%
 0:02 3%; send: 5505146 2.64 Mp/s (2.70 Mp/s avg); recv: 67326 35.0 Kp/s (33.1 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.22%
...
 1:00 98% (1s left); send: 152445504 done (2.54 Mp/s avg); recv: 1993556 28.2 Kp/s (33.2 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
 1:01 100% (0s left); send: 152445504 done (2.54 Mp/s avg); recv: 1996225 2.67 Kp/s (32.7 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
May 02 17:59:22.133 [INFO] zmap: completed

```