### PR TITLE
Add sanity-check to TCP options for loop

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -256,12 +256,11 @@ static void parse_tcp_opts(struct tcphdr *tcp, fieldset_t *fs)
 			default:
 				break;
 		}
-		// we don't want to get stuck in the loop if the TCP options are malformed, length must be at least 1
-		int safe_len = *len;
-		if (safe_len < 1) {
-			safe_len = 1;
+		// we don't want to get stuck in the loop if the TCP options are malformed, break if length is non-positive
+		if (*len < 1) {
+			break;
 		}
-		curr_idx += safe_len;
+		curr_idx += *len;
 	}
 
 	add_tcpopt_to_fs(fs, &mss, "tcpopt_mss");

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -256,8 +256,12 @@ static void parse_tcp_opts(struct tcphdr *tcp, fieldset_t *fs)
 			default:
 				break;
 		}
-
-		curr_idx += *len;
+		// we don't want to get stuck in the loop if the TCP options are malformed, length must be at least 1
+		int safe_len = *len;
+		if (safe_len < 1) {
+			safe_len = 1;
+		}
+		curr_idx += safe_len;
 	}
 
 	add_tcpopt_to_fs(fs, &mss, "tcpopt_mss");

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -14,7 +14,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <assert.h>
-#include <math.h>
 
 #include "../../lib/includes.h"
 #include "../../lib/logger.h"
@@ -208,65 +207,6 @@ static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 	return PACKET_VALID;
 }
 
-
-static void add_tcpopt_to_fs(fieldset_t *fs, int64_t *val, const char *label)
-{
-	if (*val != -1) {
-		fs_add_uint64(fs, label, *((uint64_t *) val));
-	} else {
-		fs_add_null(fs, label);
-	}
-}
-
-static void parse_tcp_opts(struct tcphdr *tcp, fieldset_t *fs)
-{
-	int64_t mss = -1, wscale = -1, sack_perm = -1, ts_val = -1, ts_ecr = -1;
-
-	size_t header_size = tcp->th_off * 4;
-	for (size_t curr_idx = 20; curr_idx < header_size; ) {
-		uint8_t *kind = ((uint8_t *) tcp) + curr_idx;
-		uint8_t *len = ((uint8_t *) tcp) + curr_idx + 1;
-		uint8_t *val = ((uint8_t *) tcp) + curr_idx + 2;
-
-		switch(*kind) {
-			case TCPOPT_EOL: // End of option list
-			case TCPOPT_NOP: // NOP
-				// EOL and NOP are 1 byte in length without any length or value fields
-				curr_idx += 1;
-				continue;
-
-			case TCPOPT_MAXSEG: // MSS
-				mss = ntohs(*(uint16_t *) val);
-				break;
-
-			case TCPOPT_WINDOW: // Window scale
-				wscale = pow(2, *((uint8_t *) val));
-				break;
-
-			case TCPOPT_SACK_PERMITTED: // SACK permitted
-				sack_perm = 1;
-				break;
-
-			case TCPOPT_TIMESTAMP: // TCP Timestamp
-				// Retrieve TS value and TS echo reply
-				ts_val = ntohl(*(uint32_t *) val);
-				ts_ecr = ntohl(*((uint32_t *) (val + 4)));
-				break;
-
-			default:
-				break;
-		}
-
-		curr_idx += *len;
-	}
-
-	add_tcpopt_to_fs(fs, &mss, "tcpopt_mss");
-	add_tcpopt_to_fs(fs, &wscale, "tcpopt_wscale");
-	add_tcpopt_to_fs(fs, &sack_perm, "tcpopt_sack_perm");
-	add_tcpopt_to_fs(fs, &ts_val, "tcpopt_ts_val");
-	add_tcpopt_to_fs(fs, &ts_ecr, "tcpopt_ts_ecr");
-}
-
 static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 				   fieldset_t *fs, UNUSED uint32_t *validation,
 				   UNUSED struct timespec ts)
@@ -281,7 +221,6 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		fs_add_uint64(fs, "seqnum", (uint64_t)ntohl(tcp->th_seq));
 		fs_add_uint64(fs, "acknum", (uint64_t)ntohl(tcp->th_ack));
 		fs_add_uint64(fs, "window", (uint64_t)ntohs(tcp->th_win));
-		parse_tcp_opts(tcp, fs);
 		if (tcp->th_flags & TH_RST) { // RST packet
 			fs_add_constchar(fs, "classification", "rst");
 			fs_add_bool(fs, "success", 0);
@@ -297,11 +236,6 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		fs_add_null(fs, "seqnum");
 		fs_add_null(fs, "acknum");
 		fs_add_null(fs, "window");
-		fs_add_null(fs, "tcpopt_mss");
-		fs_add_null(fs, "tcpopt_wscale");
-		fs_add_null(fs, "tcpopt_sack_perm");
-		fs_add_null(fs, "tcpopt_ts_val");
-		fs_add_null(fs, "tcpopt_ts_ecr");
 		// global
 		fs_add_constchar(fs, "classification", "icmp");
 		fs_add_bool(fs, "success", 0);
@@ -316,11 +250,6 @@ static fielddef_t fields[] = {
     {.name = "seqnum", .type = "int", .desc = "TCP sequence number"},
     {.name = "acknum", .type = "int", .desc = "TCP acknowledgement number"},
     {.name = "window", .type = "int", .desc = "TCP window"},
-    {.name = "tcpopt_mss", .type = "int", .desc = "TCP MSS option"},
-    {.name = "tcpopt_wscale", .type = "int", .desc = "TCP Window scale option"},
-    {.name = "tcpopt_sack_perm", .type = "int", .desc = "TCP SACK permitted option"},
-    {.name = "tcpopt_ts_val", .type = "int", .desc = "TCP timestamp option value"},
-    {.name = "tcpopt_ts_ecr", .type = "int", .desc = "TCP timestamp option echo reply"},
     CLASSIFICATION_SUCCESS_FIELDSET_FIELDS,
     ICMP_FIELDSET_FIELDS,
 };

--- a/src/recv-pcap.c
+++ b/src/recv-pcap.c
@@ -30,7 +30,7 @@
 #include "probe_modules/probe_modules.h"
 
 #define PCAP_PROMISC 1
-#define PCAP_TIMEOUT 1000
+#define PCAP_TIMEOUT 100
 
 static pcap_t *pc = NULL;
 


### PR DESCRIPTION
This fixes the bug opened in #868. The cause was if a packet came back with a TCP option in which the length was 0 (this does not conform to the spec ofc), the callback would be stuck in the loop forever. 

It also reverts the change I made in #869 that fixed PR #862 since that was not the root cause like I thought it was.

I'll close the PR #870 (which reverted the TCP options commit until I could figure out why it broke) since we should all be good now.

## Testing
With the new fix, a large scan doesn't get stuck like it did AND we don't have the 0 rec/sec message in the monitor thread every 43 seconds.
```
 0:41 67% (20s left); send: 102299450 2.40 Mp/s (2.49 Mp/s avg); recv: 1334110 31.5 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:42 69% (19s left); send: 104799774 2.50 Mp/s (2.49 Mp/s avg); recv: 1366494 32.4 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:43 71% (18s left); send: 107280122 2.48 Mp/s (2.49 Mp/s avg); recv: 1399029 32.5 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:44 72% (17s left); send: 109764410 2.48 Mp/s (2.49 Mp/s avg); recv: 1431746 32.7 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:45 74% (16s left); send: 112245626 2.48 Mp/s (2.49 Mp/s avg); recv: 1463817 32.1 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:46 75% (15s left); send: 114761978 2.52 Mp/s (2.49 Mp/s avg); recv: 1496579 32.8 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:47 77% (14s left); send: 117283578 2.52 Mp/s (2.49 Mp/s avg); recv: 1529225 32.6 Kp/s (32.5 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:48 79% (13s left); send: 120058541 2.77 Mp/s (2.50 Mp/s avg); recv: 1565490 36.2 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:49 80% (12s left); send: 122718138 2.66 Mp/s (2.50 Mp/s avg); recv: 1600673 35.2 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:50 82% (11s left); send: 125245242 2.53 Mp/s (2.50 Mp/s avg); recv: 1633638 33.0 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:51 84% (10s left); send: 127766970 2.52 Mp/s (2.50 Mp/s avg); recv: 1666846 33.2 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:52 85% (9s left); send: 130257468 2.49 Mp/s (2.50 Mp/s avg); recv: 1699147 32.3 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:53 87% (8s left); send: 132737146 2.48 Mp/s (2.50 Mp/s avg); recv: 1731153 32.0 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:54 89% (7s left); send: 135225699 2.49 Mp/s (2.50 Mp/s avg); recv: 1763774 32.6 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:55 90% (6s left); send: 137702714 2.48 Mp/s (2.50 Mp/s avg); recv: 1795981 32.2 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:56 92% (5s left); send: 140163962 2.46 Mp/s (2.50 Mp/s avg); recv: 1828478 32.5 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:57 94% (4s left); send: 142642938 2.48 Mp/s (2.50 Mp/s avg); recv: 1861072 32.6 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:58 95% (3s left); send: 145128122 2.48 Mp/s (2.50 Mp/s avg); recv: 1893231 32.1 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 0:59 97% (2s left); send: 147675130 2.55 Mp/s (2.50 Mp/s avg); recv: 1925950 32.7 Kp/s (32.6 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
 1:00 98% (1s left); send: 150252608 done (2.50 Mp/s avg); recv: 1961053 35.1 Kp/s (32.7 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
 1:01 100% (0s left); send: 150252608 done (2.50 Mp/s avg); recv: 1964161 3.11 Kp/s (32.2 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.31%
May 03 00:06:55.405 [INFO] zmap: completed
```