### PR TITLE
More robust parsing of TCP options

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -242,8 +242,9 @@ static void parse_tcp_opts(struct tcphdr *tcp, fieldset_t *fs)
 		}
 
 		uint8_t len = *(((uint8_t *) tcp) + curr_idx + 1);
-		if ((len == 0) || (curr_idx + len > header_size)) {
-			// option length is zero or extends beyond end of header
+		if ((len <= 1) || (curr_idx + len > header_size)) {
+			// option length is too small to include the length
+			// field itself, or extends beyond end of header
 			break;
 		}
 


### PR DESCRIPTION
Add full length checking to catch more types of malformed TCP options. Specifically, stop parsing options when the option's length field itself lies outside of the TCP header, or when the indicated length of the option extends beyond the end of the TCP header, or when an option has an unexpected length.

Basically a more thorough, more defensive version of the fix in #871, that will additionally prevent some classes of malformed TCP options from generating spurious fields with bad data in results.

Tested by verifying results are still the same for some test networks; did not do a full before/after diff for 0.0.0.0/0.

/cc @ogasser @phillip-stephens