### PR TITLE
Unbreak PF_RING

### DIFF
--- a/src/recv-pfring.c
+++ b/src/recv-pfring.c
@@ -31,6 +31,7 @@ void recv_init()
 		log_fatal("recv", "Could not get packet handle: %s",
 			  strerror(errno));
 	}
+	zconf.data_link_size = sizeof(struct ether_header);
 }
 
 void recv_cleanup()

--- a/src/socket-pfring.c
+++ b/src/socket-pfring.c
@@ -17,6 +17,6 @@ sock_t get_socket(uint32_t id)
 {
 	sock_t sock;
 	sock.pf.queue = zconf.pf.queues[id];
-	sock.pf.buffers = zconf.pf.buffers + 256 * id;
+	sock.pf.buffers = zconf.pf.buffers + zconf.batch * id;
 	return sock;
 }

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -50,7 +50,7 @@
 
 #ifdef PFRING
 #include <pfring_zc.h>
-static int32_t distrib_func(pfring_zc_pkt_buff *pkt, pfring_zc_queue *in_queue,
+static int64_t distrib_func(pfring_zc_pkt_buff *pkt, pfring_zc_queue *in_queue,
 			    void *arg)
 {
 	(void)pkt;
@@ -1118,7 +1118,7 @@ int main(int argc, char *argv[])
 #define QUEUE_LEN 8192
 #define ZMAP_PF_BUFFER_SIZE 1536
 #define ZMAP_PF_ZC_CLUSTER_ID 9627
-	uint32_t user_buffers = zconf.senders * 256;
+	uint32_t user_buffers = zconf.senders * zconf.batch;
 	uint32_t queue_buffers = zconf.senders * QUEUE_LEN;
 	uint32_t card_buffers = 2 * MAX_CARD_SLOTS;
 	uint32_t total_buffers =
@@ -1127,7 +1127,7 @@ int main(int argc, char *argv[])
 	uint32_t numa_node = 0; // TODO
 	zconf.pf.cluster = pfring_zc_create_cluster(
 	    ZMAP_PF_ZC_CLUSTER_ID, ZMAP_PF_BUFFER_SIZE, metadata_len,
-	    total_buffers, numa_node, NULL, NULL);
+	    total_buffers, numa_node, NULL, 0);
 	if (zconf.pf.cluster == NULL) {
 		log_fatal("zmap", "Could not create zc cluster: %s",
 			  strerror(errno));


### PR DESCRIPTION
Set zconf.data_link_size to unbreak the receive code and implement send_batch for PF_RING to unbreak the send code.  While here, also fix compiler warnings in PF_RING code.

Fixes #833.  Fixes #694.  Conflicts with #812.  (Feel free to remove PF_RING instead of fixing it.)

Tested in a VM, and seems to work fine, results and hit rate look good.  I don't have spare 10G hardware to install Linux on, so I cannot tell if ZMap with PF_RING is still able to send at 10G wire speed or not.