### PR TITLE
PF_RING: Do not delay termination by waiting for packets forever

### DIFF
--- a/src/recv-pfring.c
+++ b/src/recv-pfring.c
@@ -44,14 +44,12 @@ void recv_cleanup()
 
 void recv_packets()
 {
-	int ret;
-	// Poll for packets
-	do {
-		ret = pfring_zc_recv_pkt(pf_recv, &pf_buffer, 0);
-		if (ret == 0) {
-			usleep(1000);
-		}
-	} while (ret == 0);
+	int ret = pfring_zc_recv_pkt(pf_recv, &pf_buffer, 0);
+	// Empty queue, return to let outer loop check for termination
+	if (ret == 0) {
+		usleep(1000);
+		return;
+	}
 	// Handle other errors, by not doing anything and logging
 	if (ret != 1) {
 		log_error("recv", "Error: %d", ret);


### PR DESCRIPTION
On empty queue, return after the brief sleep instead of looping.  This lets the outer loop check its termination condition.

Fixes bug where a PF_RING based scan would not terminate even after the cooldown timer expires, until there are extra incoming packets breaking the inner loop.