### PR TITLE
the `--max-targets` flag with a percent wasn't respecting multi-ports

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -144,8 +144,9 @@ void fprintw(FILE *f, const char *s, size_t w)
 	free(news);
 }
 
-uint32_t parse_max_hosts(char *max_targets)
+uint32_t parse_max_hosts(char *max_targets, int port_count)
 {
+	assert(port_count > 0);
 	char *end;
 	errno = 0;
 	double v = strtod(max_targets, &end);
@@ -153,8 +154,8 @@ uint32_t parse_max_hosts(char *max_targets)
 		log_fatal("argparse", "can't convert max-targets to a number");
 	}
 	if (end[0] == '%' && end[1] == '\0') {
-		// treat as percentage
-		v = v * ((unsigned long long int)1 << 32) / 100.;
+		// treat as percentage of the search space, so percent of 2^32 * num_ports
+		v = v * (((unsigned long long int)1 << 32) * port_count) / 100.;
 	} else if (end[0] != '\0') {
 		log_fatal("eargparse", "extra characters after max-targets");
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -165,8 +165,6 @@ uint64_t parse_max_targets(char *max_targets, int port_count)
 	if (v <= 0) {
 		return 0;
 	} else if (v >= (((uint64_t)1 << 32) * port_count)) {
-		log_warn("argparse", "max-targets is greater than the search space, setting to search space: %lu",
-				((uint64_t)1 << 32) * port_count);
 		return (((uint64_t)1 << 32) * port_count);
 	} else {
 		return v;

--- a/lib/util.c
+++ b/lib/util.c
@@ -144,7 +144,9 @@ void fprintw(FILE *f, const char *s, size_t w)
 	free(news);
 }
 
-uint32_t parse_max_hosts(char *max_targets, int port_count)
+// parse a string representing a number/percentage of targets
+// A percentage is interpreted as percent of the search space, so 2^32 * port_count
+unsigned long long int parse_max_targets(char *max_targets, int port_count)
 {
 	assert(port_count > 0);
 	char *end;
@@ -161,8 +163,8 @@ uint32_t parse_max_hosts(char *max_targets, int port_count)
 	}
 	if (v <= 0) {
 		return 0;
-	} else if (v >= ((unsigned long long int)1 << 32)) {
-		return 0xFFFFFFFF;
+	} else if (v >= ((unsigned long long int)1 << 32 * port_count)) {
+		return ((unsigned long long int)1 << 32 * port_count);
 	} else {
 		return v;
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -165,6 +165,8 @@ uint64_t parse_max_targets(char *max_targets, int port_count)
 	if (v <= 0) {
 		return 0;
 	} else if (v >= (((uint64_t)1 << 32) * port_count)) {
+		log_warn("argparse", "max-targets is greater than the search space, setting to search space: %lu",
+				((uint64_t)1 << 32) * port_count);
 		return (((uint64_t)1 << 32) * port_count);
 	} else {
 		return v;

--- a/lib/util.c
+++ b/lib/util.c
@@ -164,8 +164,8 @@ uint64_t parse_max_targets(char *max_targets, int port_count)
 	}
 	if (v <= 0) {
 		return 0;
-	} else if (v >= (((unsigned long long int)1 << 32) * port_count)) {
-		return (((unsigned long long int)1 << 32) * port_count);
+	} else if (v >= (((uint64_t)1 << 32) * port_count)) {
+		return (((uint64_t)1 << 32) * port_count);
 	} else {
 		return v;
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -157,7 +157,8 @@ uint64_t parse_max_targets(char *max_targets, int port_count)
 	}
 	if (end[0] == '%' && end[1] == '\0') {
 		// treat as percentage of the search space, so percent of 2^32 * num_ports
-		v = v * (((unsigned long long int)1 << 32) * port_count) / 100.;
+		uint64_t search_space = ((uint64_t)1 << 32) * port_count;
+		v = v * search_space / 100.;
 	} else if (end[0] != '\0') {
 		log_fatal("eargparse", "extra characters after max-targets");
 	}

--- a/lib/util.c
+++ b/lib/util.c
@@ -146,7 +146,7 @@ void fprintw(FILE *f, const char *s, size_t w)
 
 // parse a string representing a number/percentage of targets
 // A percentage is interpreted as percent of the search space, so 2^32 * port_count
-unsigned long long int parse_max_targets(char *max_targets, int port_count)
+uint64_t parse_max_targets(char *max_targets, int port_count)
 {
 	assert(port_count > 0);
 	char *end;
@@ -163,8 +163,8 @@ unsigned long long int parse_max_targets(char *max_targets, int port_count)
 	}
 	if (v <= 0) {
 		return 0;
-	} else if (v >= ((unsigned long long int)1 << 32 * port_count)) {
-		return ((unsigned long long int)1 << 32 * port_count);
+	} else if (v >= (((unsigned long long int)1 << 32) * port_count)) {
+		return (((unsigned long long int)1 << 32) * port_count);
 	} else {
 		return v;
 	}

--- a/lib/util.h
+++ b/lib/util.h
@@ -27,7 +27,7 @@ int max_int(int a, int b);
 int min_int(int a, int b);
 uint64_t min_uint64_t(uint64_t a, uint64_t b);
 
-uint32_t parse_max_hosts(char *max_targets, int num_ports);
+unsigned long long int parse_max_targets(char *max_targets, int num_ports);
 void enforce_range(const char *name, int v, int min, int max);
 
 // Splits comma delimited string into char*[]. Does not handle

--- a/lib/util.h
+++ b/lib/util.h
@@ -27,7 +27,7 @@ int max_int(int a, int b);
 int min_int(int a, int b);
 uint64_t min_uint64_t(uint64_t a, uint64_t b);
 
-uint32_t parse_max_hosts(char *max_targets);
+uint32_t parse_max_hosts(char *max_targets, int num_ports);
 void enforce_range(const char *name, int v, int min, int max);
 
 // Splits comma delimited string into char*[]. Does not handle

--- a/lib/util.h
+++ b/lib/util.h
@@ -27,7 +27,7 @@ int max_int(int a, int b);
 int min_int(int a, int b);
 uint64_t min_uint64_t(uint64_t a, uint64_t b);
 
-uint64_t parse_max_targets(char *max_targets, int num_ports);
+uint64_t parse_max_targets(char *max_targets, int port_count);
 void enforce_range(const char *name, int v, int min, int max);
 
 // Splits comma delimited string into char*[]. Does not handle

--- a/lib/util.h
+++ b/lib/util.h
@@ -27,7 +27,7 @@ int max_int(int a, int b);
 int min_int(int a, int b);
 uint64_t min_uint64_t(uint64_t a, uint64_t b);
 
-unsigned long long int parse_max_targets(char *max_targets, int num_ports);
+uint64_t parse_max_targets(char *max_targets, int num_ports);
 void enforce_range(const char *name, int v, int min, int max);
 
 // Splits comma delimited string into char*[]. Does not handle

--- a/src/state.h
+++ b/src/state.h
@@ -166,7 +166,7 @@ struct state_send {
 	int warmup;
 	int complete;
 	uint32_t first_scanned;
-	uint32_t max_targets;
+	uint64_t max_targets;
 	uint32_t sendto_failures;
 	uint32_t max_index;
 	uint16_t max_port_index;

--- a/src/state.h
+++ b/src/state.h
@@ -215,7 +215,7 @@ struct state_recv {
 extern struct state_recv zrecv;
 
 struct port_conf {
-	int port_count;
+	uint port_count;
 	uint16_t ports[0xFFFF + 1];
 	uint8_t *port_bitmap;
 };

--- a/src/summary.c
+++ b/src/summary.c
@@ -80,7 +80,6 @@ void json_metadata(FILE *file)
 		}
 		json_object_object_add(obj, "target_ports", target_ports);
 	}
-	log_warn("json_metadata", "max_targets: %lu", zconf.max_targets);
 	json_object_object_add(obj, "max_targets",
 			       json_object_new_int(zconf.max_targets));
 	json_object_object_add(obj, "max_runtime",

--- a/src/summary.c
+++ b/src/summary.c
@@ -73,7 +73,7 @@ void json_metadata(FILE *file)
 		    json_object_new_int(zconf.source_port_last));
 
 		json_object *target_ports = json_object_new_array();
-		for (int i = 0; i < zconf.ports->port_count; i++) {
+		for (uint i = 0; i < zconf.ports->port_count; i++) {
 			json_object_array_add(
 			    target_ports,
 			    json_object_new_int(zconf.ports->ports[i]));

--- a/src/summary.c
+++ b/src/summary.c
@@ -80,6 +80,7 @@ void json_metadata(FILE *file)
 		}
 		json_object_object_add(obj, "target_ports", target_ports);
 	}
+	log_warn("json_metadata", "max_targets: %lu", zconf.max_targets);
 	json_object_object_add(obj, "max_targets",
 			       json_object_new_int(zconf.max_targets));
 	json_object_object_add(obj, "max_runtime",

--- a/src/ziterate.1
+++ b/src/ziterate.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZITERATE" "1" "February 2024" "ZMap" "ziterate"
+.TH "ZITERATE" "1" "May 2024" "ZMap" "ziterate"
 .
 .SH "NAME"
 \fBziterate\fR \- ZMap IP permutation generation file

--- a/src/ziterate.1.html
+++ b/src/ziterate.1.html
@@ -121,7 +121,7 @@ subnets will be excluded.</p></dd>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>February 2024</li>
+    <li class='tc'>May 2024</li>
     <li class='tr'>ziterate(1)</li>
   </ol>
 

--- a/src/ziterate.c
+++ b/src/ziterate.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 	conf.destination_cidrs_len = args.inputs_num;
 	// max targets
 	if (args.max_targets_given) {
-		conf.max_hosts = parse_max_hosts(args.max_targets_arg, zconf.ports->port_count);
+		conf.max_hosts = parse_max_targets(args.max_targets_arg, zconf.ports->port_count);
 	}
 
 	// sanity check blocklist file

--- a/src/ziterate.c
+++ b/src/ziterate.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 	conf.destination_cidrs_len = args.inputs_num;
 	// max targets
 	if (args.max_targets_given) {
-		conf.max_hosts = parse_max_hosts(args.max_targets_arg);
+		conf.max_hosts = parse_max_hosts(args.max_targets_arg, zconf.ports->port_count);
 	}
 
 	// sanity check blocklist file

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "April 2024" "ZMap" "zmap"
+.TH "ZMAP" "1" "July 2024" "ZMap" "zmap"
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -52,7 +52,7 @@ Set the send rate in bits/second (supports suffixes G, M, and K (e\.g\. \-B 10M 
 .
 .TP
 \fB\-n\fR, \fB\-\-max\-targets=n\fR
-Cap the number of targets to probe\. This can either be a number (e\.g\. \-n 1000) or a percentage (e\.g\. \-n 0\.1%) of the scannable address space (after excluding blocklist)\. A target is an IP/port pair, if scanning multiple ports, and an IP otherwise\.
+Cap the number of targets to probe\. This can either be a number (e\.g\. \-n 1000) or a percentage (e\.g\. \-n 0\.1%) of the scannable address space (after excluding blocklist)\. A target is an IP/port pair, if scanning multiple ports, and an IP otherwise\. In the case of percents and multiple ports, the percent is of the total number of IP/port pair combinations\.
 .
 .TP
 \fB\-N\fR, \fB\-\-max\-results=n\fR

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -121,7 +121,8 @@ be excluded.</p></dd>
 <dt> <code>-n</code>, <code>--max-targets=n</code></dt><dd><p> Cap the number of targets to probe. This can either be a number (e.g. -n
  1000) or a percentage (e.g. -n 0.1%) of the scannable address space
  (after excluding blocklist). A target is an IP/port pair, if scanning multiple
- ports, and an IP otherwise.</p></dd>
+ ports, and an IP otherwise. In the case of percents and multiple ports, the percent
+ is of the total number of IP/port pair combinations.</p></dd>
 <dt> <code>-N</code>, <code>--max-results=n</code></dt><dd><p> Exit after receiving this many results</p></dd>
 <dt> <code>-t</code>, <code>--max-runtime=secs</code></dt><dd><p> Cap the length of time for sending packets</p></dd>
 <dt> <code>-c</code>, <code>--cooldown-time=secs</code></dt><dd><p> How long to continue receiving after sending has completed (default=8)</p></dd>
@@ -305,7 +306,7 @@ decreasing by 5%.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>April 2024</li>
+    <li class='tc'>July 2024</li>
     <li class='tr'>zmap(1)</li>
   </ol>
 

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -64,7 +64,8 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      Cap the number of targets to probe. This can either be a number (e.g. -n
      1000) or a percentage (e.g. -n 0.1%) of the scannable address space
      (after excluding blocklist). A target is an IP/port pair, if scanning multiple
-     ports, and an IP otherwise.
+     ports, and an IP otherwise. In the case of percents and multiple ports, the percent
+     is of the total number of IP/port pair combinations.
 
    * `-N`, `--max-results=n`:
      Exit after receiving this many results

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -929,6 +929,7 @@ int main(int argc, char *argv[])
 
 	if (args.max_targets_given) {
 		zconf.max_targets = parse_max_targets(args.max_targets_arg, zconf.ports->port_count);
+		log_warn("zmap", "max-targets set to %u in zmap.c", zconf.max_targets);
 	}
 
 	// blocklist
@@ -961,6 +962,7 @@ int main(int argc, char *argv[])
 	}
 	if (zconf.max_targets) {
 		zsend.max_targets = zconf.max_targets;
+		log_warn("zmap","max-targets set to %u", zsend.max_targets);
 	}
 
 	// Perform network initialization before initializing

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -928,7 +928,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (args.max_targets_given) {
-		zconf.max_targets = parse_max_hosts(args.max_targets_arg);
+		zconf.max_targets = parse_max_hosts(args.max_targets_arg, zconf.ports->port_count);
 	}
 
 	// blocklist

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -928,7 +928,7 @@ int main(int argc, char *argv[])
 	}
 
 	if (args.max_targets_given) {
-		zconf.max_targets = parse_max_hosts(args.max_targets_arg, zconf.ports->port_count);
+		zconf.max_targets = parse_max_targets(args.max_targets_arg, zconf.ports->port_count);
 	}
 
 	// blocklist

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -929,7 +929,6 @@ int main(int argc, char *argv[])
 
 	if (args.max_targets_given) {
 		zconf.max_targets = parse_max_targets(args.max_targets_arg, zconf.ports->port_count);
-		log_warn("zmap", "max-targets set to %u in zmap.c", zconf.max_targets);
 	}
 
 	// blocklist
@@ -962,7 +961,6 @@ int main(int argc, char *argv[])
 	}
 	if (zconf.max_targets) {
 		zsend.max_targets = zconf.max_targets;
-		log_warn("zmap","max-targets set to %u", zsend.max_targets);
 	}
 
 	// Perform network initialization before initializing

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -40,7 +40,7 @@ option "bandwidth"              B "Set send rate in bits/second (supports suffix
 option "batch"                  - "Set batch size for how many packets to send in a single syscall. Advantageous on Linux or with netmap (default=64)"
     typestr="pps"
     optional int
-option "max-targets"            n "Cap number of targets to probe (as a number '-n 1000' or a percentage '-n 1%' of the address space). A target is an IP/port pair, if scanning multiple ports, and an IP otherwise."
+option "max-targets"            n "Cap number of targets to probe (as a number '-n 1000' or a percentage '-n 1%' of the target search space). A target is an IP/port pair, if scanning multiple ports, and an IP otherwise."
     typestr="n"
     optional string
 option "max-runtime"            t "Cap length of time for sending packets"

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -40,7 +40,7 @@ option "bandwidth"              B "Set send rate in bits/second (supports suffix
 option "batch"                  - "Set batch size for how many packets to send in a single syscall. Advantageous on Linux or with netmap (default=64)"
     typestr="pps"
     optional int
-option "max-targets"            n "Cap number of targets to probe (as a number or a percentage of the address space). A target is an IP/port pair, if scanning multiple ports, and an IP otherwise."
+option "max-targets"            n "Cap number of targets to probe (as a number '-n 1000' or a percentage '-n 1%' of the address space). A target is an IP/port pair, if scanning multiple ports, and an IP otherwise."
     typestr="n"
     optional string
 option "max-runtime"            t "Cap length of time for sending packets"

--- a/test/integration-tests/zmap_wrapper.py
+++ b/test/integration-tests/zmap_wrapper.py
@@ -8,7 +8,7 @@ PACKET_SEP = "-" * 54
 class Wrapper:
     def __init__(self, port="80", subnet="", num_of_ips=-1, threads=-1, shards=-1, shard=-1, seed=-1, iplayer=False,
                  dryrun=True, output_file="", max_runtime=-1, max_cooldown=-1, blocklist_file="", allowlist_file="",
-                 list_of_ips_file="", probes="", source_ip="", source_port="", source_mac="", rate=-1):
+                 list_of_ips_file="", probes="", source_ip="", source_port="", source_mac="", rate=-1, max_targets=""):
         self.port = port
         self.subnet = subnet
         self.num_of_ips = num_of_ips
@@ -29,6 +29,7 @@ class Wrapper:
         self.source_port = source_port
         self.source_mac = source_mac
         self.rate = rate
+        self.max_targets = max_targets
 
 
     def run(self):
@@ -72,6 +73,8 @@ class Wrapper:
             args.extend(["--source-mac=" + self.source_mac])
         if self.rate != -1:
             args.extend(["--rate=" + str(self.rate)])
+        if self.max_targets != "":
+            args.extend(["--max-targets=" + str(self.max_targets)])
 
         test_output = subprocess.run(args, stdout=subprocess.PIPE).stdout.decode('utf-8')
         packets = parse_output_into_obj_list(test_output)


### PR DESCRIPTION
## Before Fix - The `--max-targets` flag wasn't behaving as expected for a percent of the address space with multiple ports.

This manifested both in debug messages and in the ETA remaining un-changed when you use more than 1 port with this flag.

Single Port, 1% of address space
```
sudo ./src/zmap -B 100M -o "/dev/null"  --verbosity=5 -n 1% -p 80
...
Jul 02 23:08:51.018 [DEBUG] iterator: max targets is 42949672
...
 0:05 2% (5m16s left); send: 691206 139 Kp/s (137 Kp/s avg); recv: 8975 2.03 Kp/s (1.78 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 1.30%
```
2 Ports, 1 % of address space
```
sudo ./src/zmap -B 100M -o "/dev/null"  --verbosity=5 -n 1% -p 80-81
...
Jul 02 23:09:35.911 [DEBUG] iterator: max targets is 42949672
0:05 2% (5m21s left); send: 683403 135 Kp/s (135 Kp/s avg); recv: 4851 987 p/s (960 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.71%
```

## After Fix, note that `max targets` is correct _and_ the ETA is as expected

```
~/zmap-dev on  phillip/max-targets-percent-help! ⌚ 23:10:53
$ sudo ./src/zmap -B 100M -o "/dev/null"  --verbosity=5 -n 1% -p 80-81
...
Jul 02 23:11:05.208 [DEBUG] iterator: max targets is 85899345
...
 0:05 1% (10m left); send: 689020 137 Kp/s (136 Kp/s avg); recv: 4770 926 p/s (942 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.69%
```