### PR TITLE
Handle upgrade path for blacklist to blocklist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,12 @@ foreach(EACH_CONF ${CONF_FILES})
     endif()
 endforeach()
 
+# Upgrade path for old conf files
+if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
+    message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, moving to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
+    file(RENAME "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf")
+    message(STATUS "blocklist.conf has been successfully moved.")
+
 # Allow Debian Packaging
 include(InstallRequiredSystemLibraries)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,14 @@ endif()
 
 FILE(GLOB CONF_FILES "${PROJECT_SOURCE_DIR}/conf/*")
 
+# Upgrade path for old conf files - this is necessary for users upgrading from a version where we called the blocklist file blacklist.conf
+# Must occur before the install command
+if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
+    message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, moving to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
+    file(RENAME "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf")
+    message(STATUS "blocklist.conf has been successfully moved.")
+endif()
+
 message(STATUS "Default ZMap configuration file location is /etc/zmap")
 foreach(EACH_CONF ${CONF_FILES})
     get_filename_component(CONF_BASENAME ${EACH_CONF} NAME)
@@ -201,12 +209,6 @@ foreach(EACH_CONF ${CONF_FILES})
         message(WARNING "Existing configuration file detected at /etc/zmap/${CONF_BASENAME}, ${CONF_BASENAME} from sources will NOT be installed. Please check and install manually!")
     endif()
 endforeach()
-
-# Upgrade path for old conf files - this is necessary for users upgrading from a version where we called the blocklist file blacklist.conf
-if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
-    message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, moving to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
-    file(RENAME "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf")
-    message(STATUS "blocklist.conf has been successfully moved.")
 
 # Allow Debian Packaging
 include(InstallRequiredSystemLibraries)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,9 +191,11 @@ FILE(GLOB CONF_FILES "${PROJECT_SOURCE_DIR}/conf/*")
 # Upgrade path for old conf files - this is necessary for users upgrading from a version where we called the blocklist file blacklist.conf
 # Must occur before the install command
 if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
-    message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, moving to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
-    file(RENAME "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf")
-    message(STATUS "blocklist.conf has been successfully moved.")
+    message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, creating a symlink to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
+    execute_process(
+            COMMAND ${CMAKE_COMMAND} -E create_symlink "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf"
+    )
+    message(STATUS "blocklist.conf has been successfully symlinked to blacklist.conf.")
 endif()
 
 # If the zmap.conf file exists and contains the old blacklist-file option, replace it with the new blocklist-file option

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ foreach(EACH_CONF ${CONF_FILES})
     endif()
 endforeach()
 
-# Upgrade path for old conf files
+# Upgrade path for old conf files - this is necessary for users upgrading from a version where we called the blocklist file blacklist.conf
 if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
     message(STATUS "Old configuration file detected at ${CONFIG_DESTINATION}/blacklist.conf, moving to ${CONFIG_DESTINATION}/blocklist.conf to match the new flag conventions")
     file(RENAME "${CONFIG_DESTINATION}/blacklist.conf" "${CONFIG_DESTINATION}/blocklist.conf")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,30 @@ if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
     message(STATUS "blocklist.conf has been successfully moved.")
 endif()
 
+# Check if the file exists
+if(EXISTS "${CONFIG_DESTINATION}/zmap.conf")
+    # Read the file content into a variable
+    file(READ "${CONFIG_DESTINATION}/zmap.conf" FILE_CONTENTS)
+
+    # Check if the specific line exists
+    if(FILE_CONTENTS MATCHES "blacklist-file \"${CONFIG_DESTINATION}/blacklist.conf\"")
+        # Replace the line
+        string(REPLACE "blacklist-file \"${CONFIG_DESTINATION}/blacklist.conf\""
+                "blocklist-file \"${CONFIG_DESTINATION}/blocklist.conf\""
+                FILE_CONTENTS
+                "${FILE_CONTENTS}")
+
+        # Write the modified content back to the file
+        file(WRITE "${CONFIG_DESTINATION}/zmap.conf" "${FILE_CONTENTS}")
+
+        message(STATUS "Blacklist to blocklist file path successfully updated in ${CONFIG_DESTINATION}/zmap.conf.")
+    else()
+        message(STATUS "blacklist-file option does not exist in ${CONFIG_DESTINATION}/zmap.conf. No changes necessary to upgrade ZMap configuration file.")
+    endif()
+else()
+    message(STATUS "No ZMap configuration file detected at ${CONFIG_DESTINATION}/zmap.conf. No changes necessary to upgrade ZMap configuration file.")
+endif()
+
 message(STATUS "Default ZMap configuration file location is /etc/zmap")
 foreach(EACH_CONF ${CONF_FILES})
     get_filename_component(CONF_BASENAME ${EACH_CONF} NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,20 +196,15 @@ if(EXISTS "${CONFIG_DESTINATION}/blacklist.conf")
     message(STATUS "blocklist.conf has been successfully moved.")
 endif()
 
-# Check if the file exists
+# If the zmap.conf file exists and contains the old blacklist-file option, replace it with the new blocklist-file option
 if(EXISTS "${CONFIG_DESTINATION}/zmap.conf")
-    # Read the file content into a variable
     file(READ "${CONFIG_DESTINATION}/zmap.conf" FILE_CONTENTS)
 
-    # Check if the specific line exists
     if(FILE_CONTENTS MATCHES "blacklist-file \"${CONFIG_DESTINATION}/blacklist.conf\"")
-        # Replace the line
         string(REPLACE "blacklist-file \"${CONFIG_DESTINATION}/blacklist.conf\""
                 "blocklist-file \"${CONFIG_DESTINATION}/blocklist.conf\""
                 FILE_CONTENTS
                 "${FILE_CONTENTS}")
-
-        # Write the modified content back to the file
         file(WRITE "${CONFIG_DESTINATION}/zmap.conf" "${FILE_CONTENTS}")
 
         message(STATUS "Blacklist to blocklist file path successfully updated in ${CONFIG_DESTINATION}/zmap.conf.")

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -793,7 +793,7 @@ int main(int argc, char *argv[])
 	if (zconf.default_mode) {
 		log_debug(
 		    "filter",
-		    "No output filter specified. Will use default: exclude duplicates and unssuccessful");
+		    "No output filter specified. Will use default: exclude duplicates and unsuccessful");
 	} else if (args.output_filter_given &&
 		   strcmp(args.output_filter_arg, "")) {
 		// Run it through yyparse to build the expression tree


### PR DESCRIPTION
Closes #894 

## Description
If someone had installed zmap prior to changing the `blacklist` -> `blocklist`, they may have an existing `/etc/zmap/blacklist.conf` file. If this file had been changed or had any modifications in it, it will not be respected after installing the latest ZMap. The fix is to rename the existing file (if it exists) to the expected `etc/zmap/blocklist.conf`,

Additionally, (and what I believe caused #894), the contents of `zmap.conf` would have been 

```
blacklist-file "/etc/zmap/blacklist.conf"
```

If the `zmap.conf` file exists and contains that string, we'll replace it with:
```
blocklist-file "/etc/zmap/blocklist.conf"
```

Also fixed a typo.

## Testing

### `main` when there's a `blacklist.conf` file

Notice how there are both a `blacklist.conf` and a `blocklist.conf`
```
276f9edbd3c2# mkdir /etc/zmap
276f9edbd3c2# echo "hello" > /etc/zmap/blacklist.conf
276f9edbd3c2# cmake . && make -j4 && make install
...
...
f13c372b071b# ls /etc/zmap
blacklist.conf  blocklist.conf  zmap.conf
f13c372b071b# cat /etc/zmap/blacklist.conf 
hello
f13c372b071b# cat /etc/zmap/blocklist.conf
# From IANA IPv4 Special-Purpose Address Registry
# http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
# Updated 2013-05-22

0.0.0.0/8           # RFC1122: "This host on this network"
10.0.0.0/8          # RFC1918: Private-Use
100.64.0.0/10       # RFC6598: Shared Address Space
127.0.0.0/8         # RFC1122: Loopback
169.254.0.0/16      # RFC3927: Link Local
...
```

### `Phillip/894` when there's a pre-existing `blacklist.conf` file
```
276f9edbd3c2# mkdir /etc/zmap
276f9edbd3c2# echo "hello" > /etc/zmap/blacklist.conf
276f9edbd3c2# cmake . && make -j4 && make install
...
67fc06685b98# ls /etc/zmap
blacklist.conf  blocklist.conf  zmap.conf
67fc06685b98# cat /etc/zmap/blacklist.conf 
hello
67fc06685b98# cat /etc/zmap/blocklist.conf
hello

```

### `Phillip/894` with a fresh install
```
80a30c9ecba2# cmake . && make -j4 && make install
...
80a30c9ecba2# ls /etc/zmap
blocklist.conf  zmap.conf
80a30c9ecba2# cat /etc/zmap/blocklist.conf
# From IANA IPv4 Special-Purpose Address Registry
# http://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
# Updated 2013-05-22

0.0.0.0/8           # RFC1122: "This host on this network"
10.0.0.0/8          # RFC1918: Private-Use
100.64.0.0/10       # RFC6598: Shared Address Space
127.0.0.0/8         # RFC1122: Loopback
169.254.0.0/16      # RFC3927: Link Local
172.16.0.0/12       # RFC1918: Private-Use
...
```