### PR TITLE
Fixes ubuntu docker base image versions in github tests

### DIFF
--- a/.github/workflows/ubuntu-18.04.Dockerfile
+++ b/.github/workflows/ubuntu-18.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 # Set non-interactive mode so that apt-get does not prompt for input
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/ubuntu-20.04.Dockerfile
+++ b/.github/workflows/ubuntu-20.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 # Set non-interactive mode so that apt-get does not prompt for input
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.github/workflows/ubuntu-22.04.Dockerfile
+++ b/.github/workflows/ubuntu-22.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:22.04
 # Set non-interactive mode so that apt-get does not prompt for input
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Description
@amirian28 brought to my attention that our tests to ensure we don't break compilation on various generations of Ubuntu weren't working as designed.

This PR brings the docker base version in line with what the test is supposed to be testing.