### PR TITLE
Fixing #633 and #635 "Listening on all interfaces"

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -45,6 +45,7 @@ struct state_conf zconf = {
     .no_header_row = 0,
     .notes = NULL,
     .number_source_ips = 0,
+    .listen_all_interfaces = 0,
     .output_args = NULL,
     .output_fields = NULL,
     .output_fields_len = 0,

--- a/src/state.h
+++ b/src/state.h
@@ -60,6 +60,7 @@ struct state_conf {
 	// name of network interface that
 	// will be utilized for sending/receiving
 	char *iface;
+    int listen_all_interfaces;
 	// rate in packets per second
 	// that the sender will maintain
 	int rate;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -930,6 +930,9 @@ int main(int argc, char *argv[])
 	if (args.max_targets_given) {
 		zconf.max_targets = parse_max_targets(args.max_targets_arg, zconf.ports->port_count);
 	}
+    if (args.listen_all_interfaces_given) {
+		zconf.listen_all_interfaces = 1;
+	}
 
 	// blocklist
 	if (blocklist_init(zconf.allowlist_filename, zconf.blocklist_filename,

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -66,7 +66,8 @@ option "retries"                - "Max number of times to try to send packet if 
     optional int
 option "dryrun"                 d "Don't actually send packets"
     optional
-
+option "listen-all-interfaces"  - "Listen for response packets on all interfaces"
+    optional
 
 section "Scan Sharding"
 


### PR DESCRIPTION
**Bug #633 **
When starting a ZMap scan with icmp_echoscan over a certain interface with given gateway-mac and source-ip, it can happen, that the echo_reply comes in on an other interface than the echo_request was sent.
Then ZMap does not recognize this answer and it appears not to be reachable.
Trying to reach the same ip addresses with ping is possible, even if the echo_reply comes in over the "wrong" interface.

**Fix**
Was already available by #635 , however a minor change was missing to make the bpf filter compile.
`not ether src [HW-mac] (icmp6 && (ip6[40] == 129 || ip6[40] == 3 || ip6[40] == 1 || ip6[40] == 2 || ip6[40] == 4) && ip6 dst host [IP]`
(I'm using the IPv6 version of zmap, therefore icmp6 and ip6)
Removing `not ether src [HW-mac]` works perfectly fine.
My intuition says that it makes sense not filtering for HW Mac when listening on all interfaces. However, I might misunderstand how the bpf filter works.
The fix is to only add this part of the bpf filter when not listening on all interfaces in `recv-pcap.c` -- simply add `!zconf.listen_all_interfaces` for two if conditions, when creating the bpf filter.