### PR TITLE
Add source port validation CLI option and associated code to UDP module

### DIFF
--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -113,14 +113,12 @@ int bacnet_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			   uint32_t *src_ip, uint32_t *validation,
 			   const struct port_conf *ports)
 {
-	// this will reject packets that aren't UDP or ICMP and fully process ICMP
-	// packets
+	// this will reject packets that aren't UDP or ICMP and fully process ICMP packets
+	bool should_validate_source_port = true; // default to validating source port
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		// user didn't want source port validation
-		if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
-			return PACKET_INVALID;
-		}
-	} else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+		should_validate_source_port = false;
+	}
+	if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, should_validate_source_port, ports) == PACKET_INVALID) {
 		return PACKET_INVALID;
 	}
 	if (ip_hdr->ip_p == IPPROTO_UDP) {

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -21,9 +21,7 @@
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 #define ZMAP_BACNET_PACKET_LEN                             \
 	(sizeof(struct ether_header) + sizeof(struct ip) + \
@@ -117,7 +115,7 @@ int bacnet_validate_packet(const struct ip *ip_hdr, uint32_t len,
 {
 	// this will reject packets that aren't UDP or ICMP and fully process ICMP
 	// packets
-    if (validate_source_port_override == 0) {
+    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
         // user didn't want source port validation
         if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
                                    NO_SRC_PORT_VALIDATION,

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -115,18 +115,14 @@ int bacnet_validate_packet(const struct ip *ip_hdr, uint32_t len,
 {
 	// this will reject packets that aren't UDP or ICMP and fully process ICMP
 	// packets
-    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-        // user didn't want source port validation
-        if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
-                                   NO_SRC_PORT_VALIDATION,
-                                   ports) == PACKET_INVALID) {
-            return PACKET_INVALID;
-        }
-    } else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
-                                   SRC_PORT_VALIDATION,
-                                   ports) == PACKET_INVALID) {
-            return PACKET_INVALID;
-    }
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		// user didn't want source port validation
+		if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+			return PACKET_INVALID;
+		}
+	} else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+		return PACKET_INVALID;
+	}
 	if (ip_hdr->ip_p == IPPROTO_UDP) {
 		struct udphdr *udp = get_udp_header(ip_hdr, len);
 		if (!udp) {

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -18,10 +18,13 @@
 #include "probe_modules.h"
 #include "module_bacnet.h"
 #include "module_udp.h"
+#include "logger.h"
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 
 static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
+#define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
+
 
 #define ZMAP_BACNET_PACKET_LEN                             \
 	(sizeof(struct ether_header) + sizeof(struct ip) + \
@@ -114,7 +117,7 @@ int bacnet_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			   const struct port_conf *ports)
 {
 	// this will reject packets that aren't UDP or ICMP and fully process ICMP packets
-	bool should_validate_source_port = true; // default to validating source port
+	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		should_validate_source_port = false;
 	}
@@ -177,6 +180,9 @@ int bacnet_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
 	validate_source_port_override = zconf.validate_source_port_override;
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		log_debug("bacnet", "disabling source port validation");
+	}
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -178,7 +178,7 @@ void bacnet_process_packet(const u_char *packet, uint32_t len, fieldset_t *fs,
 int bacnet_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -7,8 +7,8 @@
  */
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -21,7 +21,9 @@
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 
-static bool validate_source_port_disable_override = false;
+// Source Port Validation Override by User
+// -1 = unset, 0 = disable override, 1 = enable override
+static uint8_t validate_source_port_override = -1;
 
 #define ZMAP_BACNET_PACKET_LEN                             \
 	(sizeof(struct ether_header) + sizeof(struct ip) + \
@@ -115,7 +117,7 @@ int bacnet_validate_packet(const struct ip *ip_hdr, uint32_t len,
 {
 	// this will reject packets that aren't UDP or ICMP and fully process ICMP
 	// packets
-    if (validate_source_port_disable_override == true) {
+    if (validate_source_port_override == 0) {
         // user didn't want source port validation
         if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
                                    NO_SRC_PORT_VALIDATION,
@@ -182,9 +184,7 @@ void bacnet_process_packet(const u_char *packet, uint32_t len, fieldset_t *fs,
 int bacnet_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-    if (conf->validate_source_port_override == false) {
-        validate_source_port_disable_override = true;
-    }
+    validate_source_port_override = zconf.validate_source_port_override;
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -849,19 +849,14 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
-    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-        // user didn't want source port validation
-        if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
-                                   NO_SRC_PORT_VALIDATION,
-                                   ports) == PACKET_INVALID) {
-            return PACKET_INVALID;
-        }
-    } else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
-        // either user didn't set override or they set src port validation on. Proceeding
-                                   SRC_PORT_VALIDATION,
-                                   ports) == PACKET_INVALID) {
-        return PACKET_INVALID;
-    }
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		// user didn't want source port validation
+		if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+			return PACKET_INVALID;
+		}
+	} else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+		return PACKET_INVALID;
+	}
     if (ip_hdr->ip_p == IPPROTO_UDP) {
 		struct udphdr *udp = get_udp_header(ip_hdr, len);
 		if (!udp) {

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -849,12 +849,11 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
+	bool should_validate_source_port = true; // default to validating source port
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		// user didn't want source port validation
-		if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
-			return PACKET_INVALID;
-		}
-	} else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
+		should_validate_source_port = false;
+	}
+	if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, should_validate_source_port, ports) == PACKET_INVALID) {
 		return PACKET_INVALID;
 	}
 	if (ip_hdr->ip_p == IPPROTO_UDP) {

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -580,8 +580,8 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 
 static int dns_global_initialize(struct state_conf *conf)
 {
-    validate_source_port_override = zconf.validate_source_port_override;
     setup_qtype_str_map();
+    validate_source_port_override = zconf.validate_source_port_override;
 	if (!conf->probe_args) {
 		log_fatal("dns", "Need probe args, e.g. --probe-args=\"A,example.com\"");
 	}

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -38,9 +38,9 @@
 //
 
 #include "module_dns.h"
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <assert.h>

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -63,6 +63,7 @@
 #define MAX_LABEL_RECURSION 10
 #define DNS_QR_ANSWER 1
 static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
+#define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
 
 
 // Note: each label has a max length of 63 bytes. So someone has to be doing
@@ -582,6 +583,9 @@ static int dns_global_initialize(struct state_conf *conf)
 {
 	setup_qtype_str_map();
 	validate_source_port_override = zconf.validate_source_port_override;
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		log_debug("dns", "disabling source port validation");
+	}
 	if (!conf->probe_args) {
 		log_fatal("dns", "Need probe args, e.g. --probe-args=\"A,example.com\"");
 	}
@@ -849,7 +853,7 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
-	bool should_validate_source_port = true; // default to validating source port
+	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		should_validate_source_port = false;
 	}

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -62,9 +62,8 @@
 #define BAD_QTYPE_VAL -1
 #define MAX_LABEL_RECURSION 10
 #define DNS_QR_ANSWER 1
-static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 #define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
-
+static bool should_validate_src_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT
 
 // Note: each label has a max length of 63 bytes. So someone has to be doing
 // something really annoying. Will raise a warning.
@@ -582,9 +581,9 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 static int dns_global_initialize(struct state_conf *conf)
 {
 	setup_qtype_str_map();
-	validate_source_port_override = zconf.validate_source_port_override;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+	if (conf->validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		log_debug("dns", "disabling source port validation");
+		should_validate_src_port = false;
 	}
 	if (!conf->probe_args) {
 		log_fatal("dns", "Need probe args, e.g. --probe-args=\"A,example.com\"");
@@ -853,11 +852,7 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
-	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		should_validate_source_port = false;
-	}
-	if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, should_validate_source_port, ports) == PACKET_INVALID) {
+	if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, should_validate_src_port, ports) == PACKET_INVALID) {
 		return PACKET_INVALID;
 	}
 	if (ip_hdr->ip_p == IPPROTO_UDP) {

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -857,7 +857,7 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 	} else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports) == PACKET_INVALID) {
 		return PACKET_INVALID;
 	}
-    if (ip_hdr->ip_p == IPPROTO_UDP) {
+	if (ip_hdr->ip_p == IPPROTO_UDP) {
 		struct udphdr *udp = get_udp_header(ip_hdr, len);
 		if (!udp) {
 			return PACKET_INVALID;

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -580,8 +580,8 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 
 static int dns_global_initialize(struct state_conf *conf)
 {
-    setup_qtype_str_map();
-    validate_source_port_override = zconf.validate_source_port_override;
+	setup_qtype_str_map();
+	validate_source_port_override = zconf.validate_source_port_override;
 	if (!conf->probe_args) {
 		log_fatal("dns", "Need probe args, e.g. --probe-args=\"A,example.com\"");
 	}

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -62,6 +62,10 @@
 #define BAD_QTYPE_VAL -1
 #define MAX_LABEL_RECURSION 10
 #define DNS_QR_ANSWER 1
+// Source Port Validation Override by User
+// -1 = unset, 0 = disable override, 1 = enable override
+static uint8_t validate_source_port_override = -1;
+
 
 // Note: each label has a max length of 63 bytes. So someone has to be doing
 // something really annoying. Will raise a warning.
@@ -578,7 +582,8 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 
 static int dns_global_initialize(struct state_conf *conf)
 {
-	setup_qtype_str_map();
+    validate_source_port_override = zconf.validate_source_port_override;
+    setup_qtype_str_map();
 	if (!conf->probe_args) {
 		log_fatal("dns", "Need probe args, e.g. --probe-args=\"A,example.com\"");
 	}
@@ -846,12 +851,20 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
-	if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
-				   SRC_PORT_VALIDATION,
-				   ports) == PACKET_INVALID) {
-		return PACKET_INVALID;
-	}
-	if (ip_hdr->ip_p == IPPROTO_UDP) {
+    if (validate_source_port_override == 0) {
+        // user didn't want source port validation
+        if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
+                                   NO_SRC_PORT_VALIDATION,
+                                   ports) == PACKET_INVALID) {
+            return PACKET_INVALID;
+        }
+    } else if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
+        // either user didn't set override or they set src port validation on. Proceeding
+                                   SRC_PORT_VALIDATION,
+                                   ports) == PACKET_INVALID) {
+        return PACKET_INVALID;
+    }
+    if (ip_hdr->ip_p == IPPROTO_UDP) {
 		struct udphdr *udp = get_udp_header(ip_hdr, len);
 		if (!udp) {
 			return PACKET_INVALID;

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -62,9 +62,7 @@
 #define BAD_QTYPE_VAL -1
 #define MAX_LABEL_RECURSION 10
 #define DNS_QR_ANSWER 1
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 
 // Note: each label has a max length of 63 bytes. So someone has to be doing
@@ -851,7 +849,7 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	// this does the heavy lifting including ICMP validation
-    if (validate_source_port_override == 0) {
+    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
         // user didn't want source port validation
         if (udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports,
                                    NO_SRC_PORT_VALIDATION,

--- a/src/probe_modules/module_ipip.c
+++ b/src/probe_modules/module_ipip.c
@@ -22,11 +22,10 @@
 #define MAX_UDP_PAYLOAD_LEN 200
 #define ICMP_UNREACH_HEADER_SIZE 8
 #define UNUSED __attribute__((unused))
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
 
 
+
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 static char *udp_send_msg = NULL;
 static int udp_send_msg_len = 0;
 
@@ -307,7 +306,7 @@ int ipip_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		struct udphdr *udp =
 		    (struct udphdr *)((char *)ip_hdr + 4 * ip_hdr->ip_hl);
 		uint16_t dport = ntohs(udp->uh_dport);
-		if (validate_source_port_override != 0 && check_src_port(dport, ports) == 0) {
+		if (validate_source_port_override != VALIDATE_SRC_PORT_DISABLE_OVERRIDE && !check_src_port(dport, ports)) {
 			return PACKET_INVALID;
 		}
 		if (!blocklist_is_allowed(*src_ip)) {
@@ -368,7 +367,7 @@ int ipip_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		// original packet and wouldn't have been altered by something
 		// responding on a different port
 		uint16_t dport = ntohs(udp->uh_dport);
-		if (validate_source_port_override != 0 && check_src_port(dport, ports) == 0) {
+		if (validate_source_port_override != VALIDATE_SRC_PORT_DISABLE_OVERRIDE && !check_src_port(dport, ports)) {
 			return PACKET_INVALID;
 		}
 		uint16_t sport = ntohs(udp->uh_sport);

--- a/src/probe_modules/module_ipip.c
+++ b/src/probe_modules/module_ipip.c
@@ -23,10 +23,8 @@
 #define ICMP_UNREACH_HEADER_SIZE 8
 #define UNUSED __attribute__((unused))
 
-
-
-static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 #define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
+static bool should_validate_src_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT
 static char *udp_send_msg = NULL;
 static int udp_send_msg_len = 0;
 
@@ -49,9 +47,9 @@ int ipip_global_initialize(struct state_conf *conf)
 	FILE *inp;
 
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-	validate_source_port_override = zconf.validate_source_port_override;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+	if (conf->validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		log_debug("ipip", "disabling source port validation");
+		should_validate_src_port = false;
 	}
 
 	udp_send_msg = strdup(udp_send_msg_default);
@@ -301,10 +299,6 @@ int ipip_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			 uint32_t *src_ip, uint32_t *validation,
 			 const struct port_conf *ports)
 {
-	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		should_validate_source_port = false;
-	}
 	if (ip_hdr->ip_p == IPPROTO_UDP) {
 		if ((4 * ip_hdr->ip_hl + sizeof(struct udphdr)) > len) {
 			// buffer not large enough to contain expected udp
@@ -314,7 +308,7 @@ int ipip_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		struct udphdr *udp =
 		    (struct udphdr *)((char *)ip_hdr + 4 * ip_hdr->ip_hl);
 		uint16_t dport = ntohs(udp->uh_dport);
-		if (should_validate_source_port && !check_src_port(dport, ports)) {
+		if (should_validate_src_port && !check_src_port(dport, ports)) {
 			return PACKET_INVALID;
 		}
 		if (!blocklist_is_allowed(*src_ip)) {
@@ -375,7 +369,7 @@ int ipip_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		// original packet and wouldn't have been altered by something
 		// responding on a different port
 		uint16_t dport = ntohs(udp->uh_dport);
-		if (should_validate_source_port && !check_src_port(dport, ports)) {
+		if (should_validate_src_port && !check_src_port(dport, ports)) {
 			return PACKET_INVALID;
 		}
 		uint16_t sport = ntohs(udp->uh_sport);

--- a/src/probe_modules/module_ipip.c
+++ b/src/probe_modules/module_ipip.c
@@ -48,7 +48,7 @@ int ipip_global_initialize(struct state_conf *conf)
 	FILE *inp;
 
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 
 	udp_send_msg = strdup(udp_send_msg_default);
 	udp_send_msg_len = strlen(udp_send_msg);

--- a/src/probe_modules/module_ipip.c
+++ b/src/probe_modules/module_ipip.c
@@ -1,4 +1,5 @@
 /* heavily copied from module_udp.c */
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -27,19 +27,23 @@ probe_module_t module_ntp;
 
 static int num_ports;
 static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
+#define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
 
 
 int ntp_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
 	validate_source_port_override = zconf.validate_source_port_override;
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		log_debug("ntp", "disabling source port validation");
+	}
 	return udp_global_initialize(conf);
 }
 
 int ntp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-	bool should_validate_source_port = true; // default to validating source port
+	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		should_validate_source_port = false;
 	}

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -32,7 +32,7 @@ static int8_t validate_source_port_override; // user-specified override for defa
 int ntp_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 	return udp_global_initialize(conf);
 }
 

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -39,11 +39,10 @@ int ntp_global_initialize(struct state_conf *conf)
 int ntp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-        // user wanted us not to check the source port
-        return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-                                      num_ports, NO_SRC_PORT_VALIDATION, ports);
-    }
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		// user wanted us not to check the source port
+		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports);
+	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
 				      num_ports, SRC_PORT_VALIDATION, ports);
 }

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -6,12 +6,12 @@
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <string.h>
-#include <assert.h>
 
 #include "../../lib/includes.h"
 #include "probe_modules.h"

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -26,16 +26,15 @@
 probe_module_t module_ntp;
 
 static int num_ports;
-static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 #define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
-
+static bool should_validate_src_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT
 
 int ntp_global_initialize(struct state_conf *conf)
 {
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-	validate_source_port_override = zconf.validate_source_port_override;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+	if (conf->validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		log_debug("ntp", "disabling source port validation");
+		should_validate_src_port = false;
 	}
 	return udp_global_initialize(conf);
 }
@@ -43,12 +42,8 @@ int ntp_global_initialize(struct state_conf *conf)
 int ntp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		should_validate_source_port = false;
-	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, should_validate_source_port, ports);
+				      num_ports, should_validate_src_port, ports);
 }
 
 void ntp_process_packet(const u_char *packet, UNUSED uint32_t len,

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -26,9 +26,7 @@
 probe_module_t module_ntp;
 
 static int num_ports;
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 
 int ntp_global_initialize(struct state_conf *conf)
@@ -41,7 +39,7 @@ int ntp_global_initialize(struct state_conf *conf)
 int ntp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-    if (validate_source_port_override == 0) {
+    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
         // user wanted us not to check the source port
         return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
                                       num_ports, NO_SRC_PORT_VALIDATION, ports);

--- a/src/probe_modules/module_ntp.c
+++ b/src/probe_modules/module_ntp.c
@@ -39,12 +39,12 @@ int ntp_global_initialize(struct state_conf *conf)
 int ntp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
+	bool should_validate_source_port = true; // default to validating source port
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		// user wanted us not to check the source port
-		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports);
+		should_validate_source_port = false;
 	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, SRC_PORT_VALIDATION, ports);
+				      num_ports, should_validate_source_port, ports);
 }
 
 void ntp_process_packet(const u_char *packet, UNUSED uint32_t len,

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -25,9 +25,8 @@
 
 #define ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN 24
 #define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 58
-static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 #define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
-
+static bool should_validate_src_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT
 
 probe_module_t module_tcp_synackscan;
 static uint32_t num_ports;
@@ -35,9 +34,9 @@ static uint32_t num_ports;
 static int synackscan_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
-	validate_source_port_override = zconf.validate_source_port_override;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+	if (state->validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		log_debug("tcp_synack", "disabling source port validation");
+		should_validate_src_port = false;
 	}
 	return EXIT_SUCCESS;
 }
@@ -99,10 +98,6 @@ static int synackscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 				      const struct port_conf *ports)
 {
 
-	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
-	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		should_validate_source_port = false;
-	}
 	if (ip_hdr->ip_p == IPPROTO_TCP) {
 		struct tcphdr *tcp = get_tcp_header(ip_hdr, len);
 		if (!tcp) {
@@ -111,7 +106,7 @@ static int synackscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		uint16_t sport = ntohs(tcp->th_sport);
 		uint16_t dport = ntohs(tcp->th_dport);
 		// validate source port
-		if (should_validate_source_port && !check_src_port(sport, ports)) {
+		if (should_validate_src_port && !check_src_port(sport, ports)) {
 			return PACKET_INVALID;
 		}
 		// validate destination port

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -8,6 +8,7 @@
 
 // probe module for performing TCP SYN scans
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -24,6 +24,10 @@
 
 #define ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN 24
 #define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 58
+// Source Port Validation Override by User
+// -1 = unset, 0 = disable override, 1 = enable override
+static uint8_t validate_source_port_override = -1;
+
 
 probe_module_t module_tcp_synackscan;
 static uint32_t num_ports;
@@ -31,6 +35,7 @@ static uint32_t num_ports;
 static int synackscan_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
+    validate_source_port_override = zconf.validate_source_port_override;
 	return EXIT_SUCCESS;
 }
 
@@ -99,7 +104,7 @@ static int synackscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		uint16_t sport = ntohs(tcp->th_sport);
 		uint16_t dport = ntohs(tcp->th_dport);
 		// validate source port
-		if (!check_src_port(sport, ports)) {
+		if (validate_source_port_override != 0 && !check_src_port(sport, ports)) {
 			return PACKET_INVALID;
 		}
 		// validate destination port

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -24,9 +24,7 @@
 
 #define ZMAP_TCP_SYNACKSCAN_TCP_HEADER_LEN 24
 #define ZMAP_TCP_SYNACKSCAN_PACKET_LEN 58
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 
 probe_module_t module_tcp_synackscan;
@@ -104,7 +102,7 @@ static int synackscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		uint16_t sport = ntohs(tcp->th_sport);
 		uint16_t dport = ntohs(tcp->th_dport);
 		// validate source port
-		if (validate_source_port_override != 0 && !check_src_port(sport, ports)) {
+		if (validate_source_port_override != VALIDATE_SRC_PORT_DISABLE_OVERRIDE && !check_src_port(sport, ports)) {
 			return PACKET_INVALID;
 		}
 		// validate destination port

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -33,7 +33,7 @@ static uint32_t num_ports;
 static int synackscan_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 	return EXIT_SUCCESS;
 }
 

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -8,6 +8,7 @@
 
 // probe module for performing TCP SYN scans
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -149,7 +150,6 @@ static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 				   uint32_t *src_ip, uint32_t *validation,
 				   const struct port_conf *ports)
 {
-
 	if (ip_hdr->ip_p == IPPROTO_TCP) {
 		struct tcphdr *tcp = get_tcp_header(ip_hdr, len);
 		if (!tcp) {

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -27,9 +27,7 @@
 // defaults
 static uint8_t zmap_tcp_synscan_tcp_header_len = 20;
 static uint8_t zmap_tcp_synscan_packet_len = 54;
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 
 probe_module_t module_tcp_synscan;
@@ -156,7 +154,7 @@ static int synscan_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		port_h_t sport = ntohs(tcp->th_sport);
 		port_h_t dport = ntohs(tcp->th_dport);
 		// validate source port
-		if (validate_source_port_override != 0 && !check_src_port(sport, ports)) {
+		if (validate_source_port_override != VALIDATE_SRC_PORT_DISABLE_OVERRIDE && !check_src_port(sport, ports)) {
 			return PACKET_INVALID;
 		}
 		// validate destination port

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -39,7 +39,7 @@ static int synscan_global_initialize(struct state_conf *state)
 {
 	num_source_ports =
 	    state->source_port_last - state->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 	// Based on the OS, we'll set the TCP options differently
 	if (!state->probe_args) {
 		// user didn't provide any probe args, defaulting to windows

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -71,9 +71,7 @@ const unsigned char charset_all[257] = {
     0xfd, 0xfe, 0xff, 0x00};
 
 static int num_ports;
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 probe_module_t module_udp;
 
@@ -439,7 +437,7 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len,
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-    if (validate_source_port_override == 1) {
+    if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
         // user requested we perform source port validation
         return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
                       num_ports, SRC_PORT_VALIDATION, ports);

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -145,7 +145,7 @@ int udp_global_initialize(struct state_conf *conf)
 {
 	uint32_t udp_template_max_len = 0;
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 
 	if (!conf->probe_args) {
 		log_error(
@@ -437,11 +437,10 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len,
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-    if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
-        // user requested we perform source port validation
-        return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-                      num_ports, SRC_PORT_VALIDATION, ports);
-    }
+	if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
+		// user requested we perform source port validation
+		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports);
+	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
 				      num_ports, NO_SRC_PORT_VALIDATION, ports);
 }

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -72,6 +72,7 @@ const unsigned char charset_all[257] = {
 
 static int num_ports;
 static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
+#define SOURCE_PORT_VALIDATION_MODULE_DEFAULT false; // default to NOT validating source port
 
 probe_module_t module_udp;
 
@@ -146,6 +147,9 @@ int udp_global_initialize(struct state_conf *conf)
 	uint32_t udp_template_max_len = 0;
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
 	validate_source_port_override = zconf.validate_source_port_override;
+	if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
+		log_debug("udp", "enabling source port validation");
+	}
 
 	if (!conf->probe_args) {
 		log_error(
@@ -437,7 +441,7 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len,
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
-	bool should_validate_source_port = false; // default to NOT validating source port
+	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
 	if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
 		should_validate_source_port = true;
 	}

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -8,10 +8,10 @@
 
 /* send module for performing arbitrary UDP scans */
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <unistd.h>
 #include <string.h>
 #include <assert.h>
 #include <sys/time.h>

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -138,12 +138,16 @@ static udp_payload_field_type_def_t udp_payload_template_fields[] = {
      .max_length = 4,
      .desc = "Microsecond part of Unix time in network byte order"}};
 
+static bool validate_source_port_override = false;
 void udp_set_num_ports(int x) { num_ports = x; }
 
 int udp_global_initialize(struct state_conf *conf)
 {
 	uint32_t udp_template_max_len = 0;
 	num_ports = conf->source_port_last - conf->source_port_first + 1;
+    if (conf->validate_source_port_override) {
+        validate_source_port_override = true;
+    }
 
 	if (!conf->probe_args) {
 		log_error(
@@ -435,8 +439,13 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len,
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
+    if (validate_source_port_override) {
+        // user requested we perform source port validation
+        return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
+                      num_ports, SRC_PORT_VALIDATION, ports);
+    }
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, SRC_PORT_VALIDATION, ports);
+				      num_ports, NO_SRC_PORT_VALIDATION, ports);
 }
 
 // Do very basic validation that this is an ICMP response to a packet we sent

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -437,12 +437,12 @@ void udp_process_packet(const u_char *packet, UNUSED uint32_t len,
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
+	bool should_validate_source_port = false; // default to NOT validating source port
 	if (validate_source_port_override == VALIDATE_SRC_PORT_ENABLE_OVERRIDE) {
-		// user requested we perform source port validation
-		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, SRC_PORT_VALIDATION, ports);
+		should_validate_source_port = true;
 	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, NO_SRC_PORT_VALIDATION, ports);
+				      num_ports, should_validate_source_port, ports);
 }
 
 // Do very basic validation that this is an ICMP response to a packet we sent

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -436,7 +436,7 @@ int udp_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 			uint32_t *validation, const struct port_conf *ports)
 {
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, NO_SRC_PORT_VALIDATION, ports);
+				      num_ports, SRC_PORT_VALIDATION, ports);
 }
 
 // Do very basic validation that this is an ICMP response to a packet we sent

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -36,7 +36,7 @@ static int num_ports;
 int upnp_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
-    validate_source_port_override = zconf.validate_source_port_override;
+	validate_source_port_override = zconf.validate_source_port_override;
 	udp_set_num_ports(num_ports);
 	return EXIT_SUCCESS;
 }

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -6,8 +6,8 @@
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <stdbool.h>
 #include <stdlib.h>
-#include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -22,9 +22,7 @@
 #include "module_udp.h"
 
 #define ICMP_UNREACH_HEADER_SIZE 8
-// Source Port Validation Override by User
-// -1 = unset, 0 = disable override, 1 = enable override
-static uint8_t validate_source_port_override = -1;
+static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
 
 static const char *upnp_query = "M-SEARCH * HTTP/1.1\r\n"
 				"Host:239.255.255.250:1900\r\n"
@@ -76,7 +74,7 @@ int upnp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			 uint32_t *src_ip, uint32_t *validation,
 			 const struct port_conf *ports)
 {
-    if (validate_source_port_override == 0) {
+    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
         // user didn't want src port validation
         return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
                                       num_ports, NO_SRC_PORT_VALIDATION, ports);

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -74,11 +74,10 @@ int upnp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			 uint32_t *src_ip, uint32_t *validation,
 			 const struct port_conf *ports)
 {
-    if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-        // user didn't want src port validation
-        return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-                                      num_ports, NO_SRC_PORT_VALIDATION, ports);
-    }
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		// user didn't want src port validation
+		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports);
+	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
 				      num_ports, SRC_PORT_VALIDATION, ports);
 }

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -74,12 +74,12 @@ int upnp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			 uint32_t *src_ip, uint32_t *validation,
 			 const struct port_conf *ports)
 {
+	bool should_validate_source_port = true; // default to validating source port
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
-		// user didn't want src port validation
-		return udp_do_validate_packet(ip_hdr, len, src_ip, validation, num_ports, NO_SRC_PORT_VALIDATION, ports);
+		should_validate_source_port = false;
 	}
 	return udp_do_validate_packet(ip_hdr, len, src_ip, validation,
-				      num_ports, SRC_PORT_VALIDATION, ports);
+				      num_ports, should_validate_source_port, ports);
 }
 
 void upnp_process_packet(const u_char *packet, UNUSED uint32_t len,

--- a/src/probe_modules/module_upnp.c
+++ b/src/probe_modules/module_upnp.c
@@ -23,6 +23,7 @@
 
 #define ICMP_UNREACH_HEADER_SIZE 8
 static int8_t validate_source_port_override; // user-specified override for default source port validation behavior
+#define SOURCE_PORT_VALIDATION_MODULE_DEFAULT true; // default to validating source port
 
 static const char *upnp_query = "M-SEARCH * HTTP/1.1\r\n"
 				"Host:239.255.255.250:1900\r\n"
@@ -37,6 +38,9 @@ int upnp_global_initialize(struct state_conf *state)
 {
 	num_ports = state->source_port_last - state->source_port_first + 1;
 	validate_source_port_override = zconf.validate_source_port_override;
+	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
+		log_debug("upnp", "disabling source port validation");
+	}
 	udp_set_num_ports(num_ports);
 	return EXIT_SUCCESS;
 }
@@ -74,7 +78,7 @@ int upnp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 			 uint32_t *src_ip, uint32_t *validation,
 			 const struct port_conf *ports)
 {
-	bool should_validate_source_port = true; // default to validating source port
+	bool should_validate_source_port = SOURCE_PORT_VALIDATION_MODULE_DEFAULT;
 	if (validate_source_port_override == VALIDATE_SRC_PORT_DISABLE_OVERRIDE) {
 		should_validate_source_port = false;
 	}

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -23,6 +23,11 @@
 #define OUTPUT_TYPE_STATIC 1
 #define OUTPUT_TYPE_DYNAMIC 2
 
+// Source Port Validation Override by User, overrides module default behavior
+#define VALIDATE_SRC_PORT_UNSET_OVERRIDE -1
+#define VALIDATE_SRC_PORT_DISABLE_OVERRIDE 0
+#define VALIDATE_SRC_PORT_ENABLE_OVERRIDE 1
+
 typedef struct probe_response_type {
 	const uint8_t is_success;
 	const char *name;

--- a/src/state.h
+++ b/src/state.h
@@ -52,7 +52,8 @@ struct state_conf {
 	port_h_t source_port_first;
 	port_h_t source_port_last;
     // overrides a probe module's default behavior and forces it to perform source port validation, if supported
-    bool validate_source_port_override;
+    // -1 = unset, 0 = validation disabled, 1 = validation enabled
+    int8_t validate_source_port_override;
 	// maximum number of packets that the scanner will send before
 	// terminating
 	uint64_t max_targets;

--- a/src/state.h
+++ b/src/state.h
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "../lib/includes.h"
 
@@ -50,6 +51,8 @@ struct state_conf {
 	struct port_conf *ports;
 	port_h_t source_port_first;
 	port_h_t source_port_last;
+    // overrides a probe module's default behavior and forces it to perform source port validation, if supported
+    bool validate_source_port_override;
 	// maximum number of packets that the scanner will send before
 	// terminating
 	uint64_t max_targets;

--- a/src/state.h
+++ b/src/state.h
@@ -11,7 +11,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 #include "../lib/includes.h"
 

--- a/src/state.h
+++ b/src/state.h
@@ -51,9 +51,9 @@ struct state_conf {
 	struct port_conf *ports;
 	port_h_t source_port_first;
 	port_h_t source_port_last;
-    // overrides a probe module's default behavior and forces it to perform source port validation, if supported
-    // -1 = unset, 0 = validation disabled, 1 = validation enabled
-    int8_t validate_source_port_override;
+	// overrides a probe module's default behavior and forces it to perform source port validation, if supported
+	// -1 = unset, 0 = validation disabled, 1 = validation enabled
+	int8_t validate_source_port_override;
 	// maximum number of packets that the scanner will send before
 	// terminating
 	uint64_t max_targets;

--- a/src/validate.c
+++ b/src/validate.c
@@ -15,6 +15,13 @@
 
 static aes128_ctx_t *aes128 = NULL;
 
+/*
+ * validate.c encrypts the src IP, dst IP and source port of a probe into a 16-bit value put in the IPID.
+ * We use a random key to encrypt the values, static across this ZMap run, so we can
+ * identify packets that came form this ZMap scan.
+ * This is used to validate a probe response and ensure it is a response to a probe we sent in this ZMap run.
+ */
+
 void validate_init(void)
 {
 	uint8_t key[AES128_KEY_BYTES];

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -99,8 +99,8 @@ Set which shard to scan (default=0)\. Shards are 0\-indexed in the range [0, N),
 Source port(s) to send packets from
 .
 .TP
-\fB\-\-validate\-source\-port\fR
-Used as an override to enable source port validation\. Source port validation will check that a received probe response\'s src port matches the dst port of the probe sent to that IP/port pair\. This ensures that multiple ZMap scans to the same hosts but to different ports will not interfere with each other\.
+\fB\-\-validate\-source\-port=enable|disable\fR
+Used as an override to enable/disable source port validation\. Source port validation will check that a received probe response\'s src port matches the dst port of the probe sent to that IP/port pair\. This ensures that multiple ZMap scans to the same hosts but to different ports will not interfere with each other Each module has a default behavior on whether to validate source ports or not and this overrides it\.
 .
 .TP
 \fB\-S\fR, \fB\-\-source\-ip=ip|range\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -100,7 +100,7 @@ Source port(s) to send packets from
 .
 .TP
 \fB\-\-validate\-source\-port=enable|disable\fR
-Used as an override to enable/disable source port validation\. Source port validation will check that a received probe response\'s src port matches the dst port of the probe sent to that IP/port pair\. This ensures that multiple ZMap scans to the same hosts but to different ports will not interfere with each other Each module has a default behavior on whether to validate source ports or not and this overrides it\.
+Used as an override to enable/disable source port validation\. Source port validation will check that a received probe response\'s src port matches the dst port of the probe sent to that IP/port pair\. This ensures that multiple ZMap scans to the same hosts but to different ports will not interfere with each other\. This overrides each modules default behavior on whether or not to validate source ports with probe responses\.
 .
 .TP
 \fB\-S\fR, \fB\-\-source\-ip=ip|range\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "October 2024" "ZMap" "zmap"
+.TH "ZMAP" "1" "November 2024" "ZMap" "zmap"
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -100,7 +100,7 @@ Source port(s) to send packets from
 .
 .TP
 \fB\-\-validate\-source\-port\fR
-Used as an override to enable source port validation\. Source port validation will check that a received probe response\'s dst port matches the source port of the probe sent to that IP/port pair\. This reduces false positives and ensures we only count hits from this ZMap scan instance\.
+Used as an override to enable source port validation\. Source port validation will check that a received probe response\'s src port matches the dst port of the probe sent to that IP/port pair\. This ensures that multiple ZMap scans to the same hosts but to different ports will not interfere with each other\.
 .
 .TP
 \fB\-S\fR, \fB\-\-source\-ip=ip|range\fR

--- a/src/zmap.1
+++ b/src/zmap.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ZMAP" "1" "July 2024" "ZMap" "zmap"
+.TH "ZMAP" "1" "October 2024" "ZMap" "zmap"
 .
 .SH "NAME"
 \fBzmap\fR \- The Fast Internet Scanner
@@ -97,6 +97,10 @@ Set which shard to scan (default=0)\. Shards are 0\-indexed in the range [0, N),
 .TP
 \fB\-s\fR, \fB\-\-source\-port=port|range\fR
 Source port(s) to send packets from
+.
+.TP
+\fB\-\-validate\-source\-port\fR
+Used as an override to enable source port validation\. Source port validation will check that a received probe response\'s dst port matches the source port of the probe sent to that IP/port pair\. This reduces false positives and ensures we only count hits from this ZMap scan instance\.
 .
 .TP
 \fB\-S\fR, \fB\-\-source\-ip=ip|range\fR

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -155,10 +155,11 @@ be excluded.</p></dd>
 
 <dl>
 <dt> <code>-s</code>, <code>--source-port=port|range</code></dt><dd><p> Source port(s) to send packets from</p></dd>
-<dt> <code>--validate-source-port</code></dt><dd><p> Used as an override to enable source port validation. Source port validation will
+<dt> <code>--validate-source-port=enable|disable</code></dt><dd><p> Used as an override to enable/disable source port validation. Source port validation will
  check that a received probe response's src port matches the dst port of the probe
  sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
- but to different ports will not interfere with each other.</p></dd>
+ but to different ports will not interfere with each other Each module has a default behavior
+ on whether to validate source ports or not and this overrides it.</p></dd>
 <dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
  10.0.0.1-10.0.0.9)</p></dd>
 <dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -156,9 +156,9 @@ be excluded.</p></dd>
 <dl>
 <dt> <code>-s</code>, <code>--source-port=port|range</code></dt><dd><p> Source port(s) to send packets from</p></dd>
 <dt> <code>--validate-source-port</code></dt><dd><p> Used as an override to enable source port validation. Source port validation will
- check that a received probe response's dst port matches the source port of the probe
- sent to that IP/port pair. This reduces false positives and ensures we only count hits
- from this ZMap scan instance.</p></dd>
+ check that a received probe response's src port matches the dst port of the probe
+ sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
+ but to different ports will not interfere with each other.</p></dd>
 <dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
  10.0.0.1-10.0.0.9)</p></dd>
 <dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>
@@ -310,7 +310,7 @@ decreasing by 5%.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>October 2024</li>
+    <li class='tc'>November 2024</li>
     <li class='tr'>zmap(1)</li>
   </ol>
 

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -158,8 +158,8 @@ be excluded.</p></dd>
 <dt> <code>--validate-source-port=enable|disable</code></dt><dd><p> Used as an override to enable/disable source port validation. Source port validation will
  check that a received probe response's src port matches the dst port of the probe
  sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
- but to different ports will not interfere with each other Each module has a default behavior
- on whether to validate source ports or not and this overrides it.</p></dd>
+ but to different ports will not interfere with each other. This overrides each modules
+ default behavior on whether or not to validate source ports with probe responses.</p></dd>
 <dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
  10.0.0.1-10.0.0.9)</p></dd>
 <dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>

--- a/src/zmap.1.html
+++ b/src/zmap.1.html
@@ -155,6 +155,10 @@ be excluded.</p></dd>
 
 <dl>
 <dt> <code>-s</code>, <code>--source-port=port|range</code></dt><dd><p> Source port(s) to send packets from</p></dd>
+<dt> <code>--validate-source-port</code></dt><dd><p> Used as an override to enable source port validation. Source port validation will
+ check that a received probe response's dst port matches the source port of the probe
+ sent to that IP/port pair. This reduces false positives and ensures we only count hits
+ from this ZMap scan instance.</p></dd>
 <dt> <code>-S</code>, <code>--source-ip=ip|range</code></dt><dd><p> Source address(es) to send packets from. Either single IP or range (e.g.
  10.0.0.1-10.0.0.9)</p></dd>
 <dt> <code>-G</code>, <code>--gateway-mac=addr</code></dt><dd><p> Gateway MAC address to send packets to (in case auto-detection fails)</p></dd>
@@ -306,7 +310,7 @@ decreasing by 5%.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>ZMap</li>
-    <li class='tc'>July 2024</li>
+    <li class='tc'>October 2024</li>
     <li class='tr'>zmap(1)</li>
   </ol>
 

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -115,8 +115,8 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
      Used as an override to enable/disable source port validation. Source port validation will
      check that a received probe response's src port matches the dst port of the probe
      sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
-     but to different ports will not interfere with each other Each module has a default behavior
-     on whether to validate source ports or not and this overrides it.
+     but to different ports will not interfere with each other. This overrides each modules
+     default behavior on whether or not to validate source ports with probe responses.
 
    * `-S`, `--source-ip=ip|range`:
      Source address(es) to send packets from. Either single IP or range (e.g.

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -111,11 +111,12 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
    * `-s`, `--source-port=port|range`:
      Source port(s) to send packets from
 
-   * `--validate-source-port`:
-     Used as an override to enable source port validation. Source port validation will
+   * `--validate-source-port=enable|disable`:
+     Used as an override to enable/disable source port validation. Source port validation will
      check that a received probe response's src port matches the dst port of the probe
      sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
-     but to different ports will not interfere with each other.
+     but to different ports will not interfere with each other Each module has a default behavior
+     on whether to validate source ports or not and this overrides it.
 
    * `-S`, `--source-ip=ip|range`:
      Source address(es) to send packets from. Either single IP or range (e.g.

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -111,6 +111,12 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
    * `-s`, `--source-port=port|range`:
      Source port(s) to send packets from
 
+   * `--validate-source-port`:
+     Used as an override to enable source port validation. Source port validation will
+     check that a received probe response's dst port matches the source port of the probe
+     sent to that IP/port pair. This reduces false positives and ensures we only count hits
+     from this ZMap scan instance.
+
    * `-S`, `--source-ip=ip|range`:
      Source address(es) to send packets from. Either single IP or range (e.g.
      10.0.0.1-10.0.0.9)

--- a/src/zmap.1.ronn
+++ b/src/zmap.1.ronn
@@ -113,9 +113,9 @@ on a gigabit network connection, reaching ~98% theoretical line speed.
 
    * `--validate-source-port`:
      Used as an override to enable source port validation. Source port validation will
-     check that a received probe response's dst port matches the source port of the probe
-     sent to that IP/port pair. This reduces false positives and ensures we only count hits
-     from this ZMap scan instance.
+     check that a received probe response's src port matches the dst port of the probe
+     sent to that IP/port pair. This ensures that multiple ZMap scans to the same hosts
+     but to different ports will not interfere with each other.
 
    * `-S`, `--source-ip=ip|range`:
      Source address(es) to send packets from. Either single IP or range (e.g.

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -640,14 +640,14 @@ int main(int argc, char *argv[])
 		    " If you have modified the default blocklist, you can ignore this message.");
 	}
 	SET_IF_GIVEN(zconf.allowlist_filename, allowlist_file);
-    zconf.validate_source_port_override = -1;
+    zconf.validate_source_port_override = VALIDATE_SRC_PORT_UNSET_OVERRIDE;
     if (args.validate_source_port_given) {
         if (strcmp(args.validate_source_port_arg, "enable") == 0) {
             // user wants to force source port validation
-            zconf.validate_source_port_override = 1;
+            zconf.validate_source_port_override = VALIDATE_SRC_PORT_ENABLE_OVERRIDE;
         } else if (strcmp(args.validate_source_port_arg, "disable") == 0) {
             // user wants to force disable source port validation
-            zconf.validate_source_port_override = 0;
+            zconf.validate_source_port_override = VALIDATE_SRC_PORT_DISABLE_OVERRIDE;
         } else {
             // unknown value
             log_fatal("zmap",

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -640,8 +640,19 @@ int main(int argc, char *argv[])
 		    " If you have modified the default blocklist, you can ignore this message.");
 	}
 	SET_IF_GIVEN(zconf.allowlist_filename, allowlist_file);
+    zconf.validate_source_port_override = -1;
     if (args.validate_source_port_given) {
-        zconf.validate_source_port_override = 1;
+        if (strcmp(args.validate_source_port_arg, "enable") == 0) {
+            // user wants to force source port validation
+            zconf.validate_source_port_override = 1;
+        } else if (strcmp(args.validate_source_port_arg, "disable") == 0) {
+            // user wants to force disable source port validation
+            zconf.validate_source_port_override = 0;
+        } else {
+            // unknown value
+            log_fatal("zmap",
+                      "unknown value for --validate-source-port, use either \"enable\" or \"disable\"");
+        }
     }
 	if (zconf.probe_module->port_args) {
 		if (args.source_port_given) {

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -640,20 +640,19 @@ int main(int argc, char *argv[])
 		    " If you have modified the default blocklist, you can ignore this message.");
 	}
 	SET_IF_GIVEN(zconf.allowlist_filename, allowlist_file);
-    zconf.validate_source_port_override = VALIDATE_SRC_PORT_UNSET_OVERRIDE;
-    if (args.validate_source_port_given) {
-        if (strcmp(args.validate_source_port_arg, "enable") == 0) {
-            // user wants to force source port validation
-            zconf.validate_source_port_override = VALIDATE_SRC_PORT_ENABLE_OVERRIDE;
-        } else if (strcmp(args.validate_source_port_arg, "disable") == 0) {
-            // user wants to force disable source port validation
-            zconf.validate_source_port_override = VALIDATE_SRC_PORT_DISABLE_OVERRIDE;
-        } else {
-            // unknown value
-            log_fatal("zmap",
-                      "unknown value for --validate-source-port, use either \"enable\" or \"disable\"");
-        }
-    }
+	zconf.validate_source_port_override = VALIDATE_SRC_PORT_UNSET_OVERRIDE;
+	if (args.validate_source_port_given) {
+		if (strcmp(args.validate_source_port_arg, "enable") == 0) {
+			// user wants to force source port validation
+			zconf.validate_source_port_override = VALIDATE_SRC_PORT_ENABLE_OVERRIDE;
+		} else if (strcmp(args.validate_source_port_arg, "disable") == 0) {
+			// user wants to force disable source port validation
+			zconf.validate_source_port_override = VALIDATE_SRC_PORT_DISABLE_OVERRIDE;
+		} else {
+			// unknown value
+			log_fatal("zmap", "unknown value for --validate-source-port, use either \"enable\" or \"disable\"");
+		}
+	}
 	if (zconf.probe_module->port_args) {
 		if (args.source_port_given) {
 			char *dash = strchr(args.source_port_arg, '-');

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -640,7 +640,9 @@ int main(int argc, char *argv[])
 		    " If you have modified the default blocklist, you can ignore this message.");
 	}
 	SET_IF_GIVEN(zconf.allowlist_filename, allowlist_file);
-
+    if (args.validate_source_port_given) {
+        zconf.validate_source_port_override = 1;
+    }
 	if (zconf.probe_module->port_args) {
 		if (args.source_port_given) {
 			char *dash = strchr(args.source_port_arg, '-');

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -84,7 +84,7 @@ section "Network Options"
 option "source-port"            s "Source port(s) for scan packets"
     typestr="port|range"
     optional string
-option "validate-source-port" - "Override to validate if probe responses have a valid dst port corresponding to sent probe's src port"
+option "validate-source-port" - "Override to validate if probe responses have a valid src port corresponding to sent probe's dst port"
     optional
 option "source-ip"              S "Source address(es) for scan packets"
     typestr="ip|range"

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -84,8 +84,9 @@ section "Network Options"
 option "source-port"            s "Source port(s) for scan packets"
     typestr="port|range"
     optional string
-option "validate-source-port" - "Override to validate if probe responses have a valid src port corresponding to sent probe's dst port"
-    optional
+option "validate-source-port" - "Override to validate if probe responses have a valid src port corresponding to sent probe's dst port. \"enable\" or \"disable\""
+    typestr="enable|disable"
+    optional string
 option "source-ip"              S "Source address(es) for scan packets"
     typestr="ip|range"
     optional string

--- a/src/zopt.ggo.in
+++ b/src/zopt.ggo.in
@@ -84,6 +84,8 @@ section "Network Options"
 option "source-port"            s "Source port(s) for scan packets"
     typestr="port|range"
     optional string
+option "validate-source-port" - "Override to validate if probe responses have a valid dst port corresponding to sent probe's src port"
+    optional
 option "source-ip"              S "Source address(es) for scan packets"
     typestr="ip|range"
     optional string


### PR DESCRIPTION
The udp module is the only module that has source port validation off by default. This flag (`--validate-source-port`) allows the user to override this behavior and perform source port validation.

