### PR TITLE
Missed a uint32

### DIFF
--- a/src/shard.c
+++ b/src/shard.c
@@ -116,7 +116,7 @@ void shard_init(shard_t *shard, uint16_t shard_idx, uint16_t num_shards,
 
 	// Set max_targets if applicable
 	if (max_total_targets > 0) {
-		uint32_t max_targets_this_shard =
+		uint64_t max_targets_this_shard =
 		    max_total_targets / num_subshards;
 		if (sub_idx < (max_total_targets % num_subshards)) {
 			++max_targets_this_shard;


### PR DESCRIPTION
Resolves #911 

## Testing + Proof of Resolution

Command on 5B targets- `sudo ./src/zmap -T 1 -B 2G -p 80-84 -o /dev/null --cores=0,1,2 --status-updates-file=/tmp/911-uint32.80-84.status -n 5000000000` 

### `main`
```
15:13 14% (1h33m left); send: 699658367 764 Kp/s (766 Kp/s avg); recv: 2291532 2.58 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:14 14% (1h33m left); send: 700450367 792 Kp/s (766 Kp/s avg); recv: 2294078 2.54 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:15 14% (1h33m left); send: 701237631 787 Kp/s (766 Kp/s avg); recv: 2296795 2.72 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:16 14% (1h33m left); send: 702027647 790 Kp/s (766 Kp/s avg); recv: 2299372 2.58 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:17 14% (1h33m left); send: 702807103 779 Kp/s (766 Kp/s avg); recv: 2301958 2.59 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:18 14% (1h33m left); send: 703567556 760 Kp/s (766 Kp/s avg); recv: 2304459 2.50 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:19 14% (1h33m left); send: 704348928 781 Kp/s (766 Kp/s avg); recv: 2307017 2.56 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:20 99% (8s left); send: 705032704 done (766 Kp/s avg); recv: 2309568 2.55 Kp/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:21 99% (7s left); send: 705032704 done (766 Kp/s avg); recv: 2309670 102 p/s (2.51 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:22 99% (6s left); send: 705032704 done (766 Kp/s avg); recv: 2309675 5 p/s (2.50 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:23 99% (5s left); send: 705032704 done (766 Kp/s avg); recv: 2309675 0 p/s (2.50 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:24 100% (4s left); send: 705032704 done (766 Kp/s avg); recv: 2309676 1 p/s (2.50 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:25 100% (3s left); send: 705032704 done (766 Kp/s avg); recv: 2309677 1 p/s (2.50 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:26 100% (2s left); send: 705032704 done (766 Kp/s avg); recv: 2309677 0 p/s (2.49 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:27 100% (1s left); send: 705032704 done (766 Kp/s avg); recv: 2309677 0 p/s (2.49 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
15:28 100% (0s left); send: 705032704 done (766 Kp/s avg); recv: 2309677 0 p/s (2.49 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
```

### `Phillip/911-uint32`
```
1:41:45 100% (10s left); send: 4998374783 844 Kp/s (819 Kp/s avg); recv: 16381684 2.73 Kp/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:46 100% (9s left); send: 4999220927 846 Kp/s (819 Kp/s avg); recv: 16384524 2.84 Kp/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:47 100% (8s left); send: 5000000000 done (819 Kp/s avg); recv: 16387145 2.62 Kp/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:48 100% (7s left); send: 5000000000 done (819 Kp/s avg); recv: 16387421 276 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:49 100% (6s left); send: 5000000000 done (819 Kp/s avg); recv: 16387424 3 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:50 100% (5s left); send: 5000000000 done (819 Kp/s avg); recv: 16387425 1 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:51 100% (4s left); send: 5000000000 done (819 Kp/s avg); recv: 16387425 0 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:52 100% (3s left); send: 5000000000 done (819 Kp/s avg); recv: 16387426 1 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:53 100% (2s left); send: 5000000000 done (819 Kp/s avg); recv: 16387426 0 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:54 100% (1s left); send: 5000000000 done (819 Kp/s avg); recv: 16387426 0 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
1:41:55 100% (0s left); send: 5000000000 done (819 Kp/s avg); recv: 16387427 1 p/s (2.68 Kp/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.33%
Dec 03 21:37:16.776 [INFO] zmap: completed

```