### PR TITLE
use the x86 ubuntu dockerfile base image, should fix failing daily test

### DIFF
--- a/.github/workflows/scan_coverage.yml
+++ b/.github/workflows/scan_coverage.yml
@@ -18,7 +18,7 @@ env:
   WITH_AES_HW: ON
 
 jobs:
-  example_job:
+  daily_scan_coverage_test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scan_coverage_pytest.Dockerfile
+++ b/.github/workflows/scan_coverage_pytest.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:latest
+FROM ubuntu:latest
 
 RUN apt-get update
 RUN apt-get install -y build-essential cmake libgmp3-dev gengetopt libpcap-dev flex byacc libjson-c-dev pkg-config \


### PR DESCRIPTION
This PR fixes the daily scan coverage test with `--fast-dryrun`. The old docker image is arm only so we'll need to remove so it runs on the x86 VMs from Github Actions.

Ran a manual action to verify - https://github.com/zmap/zmap/actions/runs/12362461674