### PR TITLE
Fix size of recv validation from uint32[16] to uint32[4]

### DIFF
--- a/src/recv.c
+++ b/src/recv.c
@@ -62,7 +62,7 @@ void handle_packet(uint32_t buflen, const u_char *bytes,
 		}
 	}
 
-	uint32_t validation[VALIDATE_BYTES / sizeof(uint8_t)];
+	uint32_t validation[VALIDATE_BYTES / sizeof(uint32_t)];
 	// TODO: for TTL exceeded messages, ip_hdr->saddr is going to be
 	// different and we must calculate off potential payload message instead
 	validate_gen(ip_hdr->ip_dst.s_addr, ip_hdr->ip_src.s_addr, src_port,


### PR DESCRIPTION
Fix the size of the validation buffer in the recv code to be `uint32[4]`, not `uint32[16]`.  The new size matches what the send code uses, and the buffer size `validate_gen` expects and writes.