### PR TITLE
netmap: Fix if_get_stats to use uint64_t to match recent globals change

### DIFF
--- a/src/if-netmap-bsd.c
+++ b/src/if-netmap-bsd.c
@@ -117,17 +117,16 @@ bool if_stats_have_recv_ctr(if_stats_ctx_t *ctx)
 	return ctx->hwstats;
 }
 
-int if_stats_get(if_stats_ctx_t *ctx, uint32_t *ps_recv, uint32_t *ps_drop, uint32_t *ps_ifdrop)
+int if_stats_get(if_stats_ctx_t *ctx, uint64_t *ps_recv, uint64_t *ps_drop, uint64_t *ps_ifdrop)
 {
 	struct if_data ifd;
 	bzero(&ifd, sizeof(ifd));
 	fetch_if_data(&ifd, ctx->ifname, ctx->fd);
 
 	if (ctx->hwstats) {
-		*ps_recv = (uint32_t)(ifd.ifi_ipackets - ctx->ifi_ipackets);
+		*ps_recv = ifd.ifi_ipackets - ctx->ifi_ipackets;
 	}
-	*ps_drop = (uint32_t)(ifd.ifi_iqdrops - ctx->ifi_iqdrops);
-	*ps_ifdrop = (uint32_t)(ifd.ifi_ierrors - ctx->ifi_ierrors +
-				ifd.ifi_oerrors - ctx->ifi_oerrors);
+	*ps_drop = ifd.ifi_iqdrops - ctx->ifi_iqdrops;
+	*ps_ifdrop = ifd.ifi_ierrors - ctx->ifi_ierrors + ifd.ifi_oerrors - ctx->ifi_oerrors;
 	return 0;
 }

--- a/src/if-netmap-linux.c
+++ b/src/if-netmap-linux.c
@@ -206,15 +206,14 @@ bool if_stats_have_recv_ctr(UNUSED if_stats_ctx_t *ctx)
 	return false;
 }
 
-int if_stats_get(if_stats_ctx_t *ctx, UNUSED uint32_t *ps_recv, uint32_t *ps_drop, uint32_t *ps_ifdrop)
+int if_stats_get(if_stats_ctx_t *ctx, UNUSED uint64_t *ps_recv, uint64_t *ps_drop, uint64_t *ps_ifdrop)
 {
 	struct rtnl_link_stats64 rtlstats64;
 	memset(&rtlstats64, 0, sizeof(rtlstats64));
 	fetch_stats64(&rtlstats64, ctx->ifname, ctx->nlrtfd);
 
-	//*ps_recv = (uint32_t)(rtlstats64.rx_packets - ctx->rx_packets);
-	*ps_drop = (uint32_t)(rtlstats64.rx_dropped - ctx->rx_dropped);
-	*ps_ifdrop = (uint32_t)(rtlstats64.rx_errors - ctx->rx_errors +
-				rtlstats64.tx_errors - ctx->tx_errors);
+	//*ps_recv = rtlstats64.rx_packets - ctx->rx_packets;
+	*ps_drop = rtlstats64.rx_dropped - ctx->rx_dropped;
+	*ps_ifdrop = rtlstats64.rx_errors - ctx->rx_errors + rtlstats64.tx_errors - ctx->tx_errors;
 	return 0;
 }

--- a/src/if-netmap.h
+++ b/src/if-netmap.h
@@ -49,7 +49,7 @@ bool if_stats_have_recv_ctr(if_stats_ctx_t *ctx);
 // netmap mode.  In that case, *ps_recv* will not be set.
 // Check if_stats_have_recv_ctr() for whether the interface
 // supports received packet count in netmap mode.
-int if_stats_get(if_stats_ctx_t *ctx, uint32_t *ps_recv, uint32_t *ps_drop, uint32_t *ps_ifdrop);
+int if_stats_get(if_stats_ctx_t *ctx, uint64_t *ps_recv, uint64_t *ps_drop, uint64_t *ps_ifdrop);
 
 // Clean up and invalidate the if_stats_* context.
 void if_stats_fini(if_stats_ctx_t *ctx);


### PR DESCRIPTION
In 94867b0, the global counters zrecv.pcap_recv, .pcap_drop and .pcap_ifdrop were enlarged from uint32_t to uint64_t.  This resulted in pointer mismatches in the netmap code that updates those counters, and still expected 32-bit counters.

Going full 64-bit also removes the need to truncate netmap's internal 64-bit counters to 32 bits.