### PR TITLE
Update built ubuntu GH runner to use latest rather than 20.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/zmap/builder:2023-09-10
       volumes:


### PR DESCRIPTION
The GH Ubuntu 20.04 runner will be [deprecated](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/) and this test will begin failing. We already have an `Ubuntu 20.04` compilation test so updating this shouldn't have any negative effects.