### PR TITLE
Fix Failing FreeBSD CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -150,7 +150,7 @@ jobs:
           envs: 'ENABLE_DEVELOPMENT ENABLE_LOG_TRACE'
           usesh: true
           prepare: |
-            freebsd-update fetch
+            freebsd-update cron
             freebsd-update install
             pkg install -y judy byacc cmake flex gengetopt gmp json-c libunistring influxpkg-config python3
           run: cd ~/work/zmap/zmap && cmake -DENABLE_DEVELOPMENT=${{env.ENABLE_DEVELOPMENT}} -DENABLE_LOG_TRACE=${{env.ENABLE_LOG_TRACE}} . && make && python3 ./scripts/check_manfile.py


### PR DESCRIPTION
This should resolve our `cmake.yml` CI, and keep this badge from showing an ominous "Failing"

![image](https://github.com/user-attachments/assets/531bdb88-0b47-4fca-b8c4-6d125f223be5)
