### PR TITLE
Remove unused functions from aesrand

### DIFF
--- a/src/aesrand.c
+++ b/src/aesrand.c
@@ -44,15 +44,6 @@ aesrand_t *aesrand_init_from_seed(uint64_t seed)
 	return _aesrand_init(key);
 }
 
-aesrand_t *aesrand_init_from_random(void)
-{
-	uint8_t key[AES128_KEY_BYTES];
-	if (!random_bytes(key, sizeof(key))) {
-		log_fatal("aesrand", "Couldn't get random bytes");
-	}
-	return _aesrand_init(key);
-}
-
 uint64_t aesrand_getword(aesrand_t *aes)
 {
 	uint64_t retval;

--- a/src/aesrand.h
+++ b/src/aesrand.h
@@ -13,12 +13,8 @@
 
 typedef struct aesrand aesrand_t;
 
-aesrand_t *aesrand_init_from_random(void);
-
 aesrand_t *aesrand_init_from_seed(uint64_t);
 
 uint64_t aesrand_getword(aesrand_t *aes);
-
-aesrand_t *aesrand_free(aesrand_t *aes);
 
 #endif


### PR DESCRIPTION
Issue #942 flagged that we didn't have an implementation for the `aesrand_free` we'd defined in the `aesrand.h` file. The approach across ZMap is to free memory that is allocated, used, and discarded over a scan (so that the memory usage of ZMap doesn't grow unbounded), but all memory that is initialized once is left to be cleaned up on process exit by the OS.

To that end, I'm not going to implement it but we can remove the unused code here.

Resolves #942 