### PR TITLE
Fix bug of not explicitly binding to socket in send-linux

### DIFF
--- a/src/get_gateway-linux.h
+++ b/src/get_gateway-linux.h
@@ -271,7 +271,8 @@ int get_default_gw(struct in_addr *gw, char *iface)
 		    "The specified network (\"%s\") does not match "
 		    "the interface associated with the default gateway (%s). You will "
 		    "need to manually specify the MAC address of your gateway using "
-		    "the \"--gateway-mac\" flag.",
+		    "the \"--gateway-mac\" flag or use \"--iplayer\" to send IP packets and "
+		    "let the kernel take care of ethernet frame creation.",
 		    iface, _iface);
 	}
 	return EXIT_SUCCESS;

--- a/src/send-linux.c
+++ b/src/send-linux.c
@@ -58,6 +58,12 @@ int send_run_init(sock_t s)
 	}
 	int ifindex = if_idx.ifr_ifindex;
 
+	// Bind to Socket. Without this, sometimes the specified interface wouldn't actually be used for sending traffic
+	if (setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, if_idx.ifr_ifrn.ifrn_name, strlen(if_idx.ifr_ifrn.ifrn_name)) < 0) {
+		log_error("send", "cannot bind to socket: %s", strerror(errno));
+		return EXIT_FAILURE;
+	}
+
 	// destination address for the socket
 	memset((void *)&sockaddr, 0, sizeof(struct sockaddr_ll));
 	sockaddr.sll_ifindex = ifindex;


### PR DESCRIPTION
It seems that since we're using raw IP sockets, we need to explicitly bind to the socket to ensure we use it. I don't claim to fully understand what's happening internally here, but I tested extensively and everything seems to work as expected.

The entry in `man socket` for `SO_BINDTODEVICE` [here](https://man7.org/linux/man-pages/man7/socket.7.html) mentions it as the socket option for binding to a IP socket. What it doesn't say and what I couldn't find documented anywhere is why the prior approach of setting the interface index on the socket works with raw sockets and _sometimes_ IP sockets, but not always. In conclusion, not sure why we need to _also_ add this socket option when using IP sockets, but it does seem to fix the problem.

## Testing

Each case was run while `tcpdump` was running to confirm the correct interface was selected

### Linux (Ubuntu 24.04)
`tcpdump`
```shell
sudo tcpdump -i any -nn '(tcp and dst port 53 and host 1.1.1.1)' -q
```

- [x] Base Case - Wireguard not running - Send TCP 1.1.1.1:53, interface not specified
    - Outcome -  Traffic sent out default interface
- [x] Base Case - Wireguard not running - Send TCP 1.1.1.1:53, interface specified as loopback
    - Outcome -  Error without specifying `gateway-mac`, packet sent on `lo` after specifying (expected)
- [x] Base Case - Wireguard not running - Send TCP 1.1.1.1:53, interface not specified, `--iplayer`
    - Outcome -  Packet sent on default interface
- [x] Base Case - Wireguard not running - Send TCP 1.1.1.1:53, interface specified as loopback, `iplayer`
    - Outcome -  Expected
- [x] Wireguard running, AllowedIPs `0.0.0.0/0` (all traffic thru Wireguard) - Send TCP 1.1.1.1:53, no interface specified
    - Outcome -  Traffic takes the `wg0` interface, expected
- [x] Wireguard running, AllowedIPs `0.0.0.0/0` (all traffic thru Wireguard) - Send TCP 1.1.1.1:53, Specify `wg0`
    - Outcome -  Get error that we can't get the MAC address of the `wg0` network, expected. Fixed error msg to inform users of using the `--iplayer` flag.
- [x] Wireguard running, AllowedIPs `0.0.0.0/0` (all traffic thru Wireguard) - Send TCP 1.1.1.1:53, no interface specified, `--iplayer`
    - Outcome -  Success, sent out on the `wg0` interface
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 1.1.1.1:53, Specify `wg0`, `--iplayer`
    - Outcome -  Success, sent on `wg0`
- [x] Wireguard running, AllowedIPs ``1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 1.1.1.1:53, no interface specified
    - Outcome -  Received error (expected) `get_gateway: Unexpected hardware address length (0). If you are using a VPN, supply the --iplayer flag (and provide an interface via -i)`
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 1.1.1.1:53, Specify `wg0`
    - Outcome -  Received error (expected) advise users to use `--iplayer`
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 1.1.1.1:53, no interface specified, `--iplayer`
    - Outcome -  SYN sent on `enp0s8` (default interface). We do warn users this is occurring in `debug` logs and I think it's the best we can do since we're bypassing the kernel's IP routing tables with our raw IP socket.
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 1.1.1.1:53, Specify `wg0`, `--iplayer`
    - Outcome -  Traffic sent out on `wg0`
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 8.8.8.8:53 (not a `wg0` allowed IP),  no interface specified, `--iplayer`
    - Outcome -  SYN sent on `enp0s8` (default interface). We do warn users this is occurring in `debug` logs and I think it's the best we can do since we're bypassing the kernel's IP routing tables with our raw IP socket.
- [x] Wireguard running, AllowedIPs `1.1.1.0/24` (only that subnet allowed thru Wireguard) - Send TCP 8.8.8.8:53 (not a `wg0` allowed IP), --interface wg0, `--iplayer`
    - Outcome -  Multiple errors when send was retried. It seems we successfully try to send on `wg0` but Wireguard has internal logic to prevent traffic to non-allowed IPs from going out on that interface.
    
   ## Related Issues
Resolves #955 
