### PR TITLE
Fix failing FreeBSD integration

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -153,5 +153,6 @@ jobs:
           prepare: |
             freebsd-update cron
             freebsd-update install
-            pkg install -y judy byacc cmake flex gengetopt gmp json-c libunistring influxpkg-config python3
+            pkg update
+            pkg install -y Judy byacc cmake flex gengetopt gmp json-c libunistring influxpkg-config python3
           run: cd ~/work/zmap/zmap && cmake -DENABLE_DEVELOPMENT=${{env.ENABLE_DEVELOPMENT}} -DENABLE_LOG_TRACE=${{env.ENABLE_LOG_TRACE}} . && make && python3 ./scripts/check_manfile.py


### PR DESCRIPTION
Not sure why all of a sudden the absence of updating the package store in FreeBSD started falling, but this seems to fix our tests.