### PR TITLE
security: fix heap corruption in DNS TXT rdlength=0 crash

### DIFF
--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -515,7 +515,11 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 			}
 		}
 	} else if (type == DNS_QTYPE_TXT) {
-		if (rdlength >= 1 && (rdlength - 1) != *(uint8_t *)rdata) {
+		if (rdlength == 0) {
+			log_warn("dns", "TXT record with rdlength=0. Skipping.");
+			fs_add_uint64(afs, "rdata_is_parsed", 0);
+			fs_add_binary(afs, "rdata", rdlength, rdata, 0);
+		} else if (rdlength >= 1 && (rdlength - 1) != *(uint8_t *)rdata) {
 			log_warn(
 			    "dns",
 			    "TXT record with wrong TXT len. Not processing.");


### PR DESCRIPTION
## Summary

When rdlength is 0, the DNS TXT parsing code would:
1. xmalloc(0) allocates a zero-size buffer
2. memcpy(txt, rdata + 1, rdlength - 1) underflows uint16_t to 65535
3. Writing ~64KB to a 0-byte buffer causes heap corruption

## Changes

### src/probe_modules/module_dns.c
Added explicit rdlength==0 check before TXT parsing:


Fixes #962