### PR TITLE
Fix FreeBSD CI runner

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -151,8 +151,7 @@ jobs:
           envs: 'ENABLE_DEVELOPMENT ENABLE_LOG_TRACE'
           usesh: true
           prepare: |
-            freebsd-update cron
-            freebsd-update install
             pkg update
+            pkg upgrade -y
             pkg install -y Judy byacc cmake flex gengetopt gmp json-c libunistring influxpkg-config python3
           run: cd ~/work/zmap/zmap && cmake -DENABLE_DEVELOPMENT=${{env.ENABLE_DEVELOPMENT}} -DENABLE_LOG_TRACE=${{env.ENABLE_LOG_TRACE}} . && make && python3 ./scripts/check_manfile.py


### PR DESCRIPTION
Looks like Github updated their FreeBSD runner

The `freebsd-update` was deprecated in favor of just `pkg update`.

This PR updates our CI runner so it works again.