### PR TITLE
Fix array out-of-bounds indexing in get_gateway-bsd.h

### DIFF
--- a/src/get_gateway-bsd.h
+++ b/src/get_gateway-bsd.h
@@ -189,7 +189,7 @@ int _get_default_gw(struct in_addr *gw, char **iface)
 				}
 				char *_iface = xmalloc(sdl->sdl_nlen + 1);
 				memcpy(_iface, sdl->sdl_data, sdl->sdl_nlen);
-				_iface[sdl->sdl_nlen + 1] = 0;
+				_iface[sdl->sdl_nlen] = 0;
 				*iface = _iface;
 			}
 			if ((1 << i) == RTA_GATEWAY) {


### PR DESCRIPTION
This fixes a silent memory bug in `get_gateway-bsd.h`.

The issue was here:
```c
				char *_iface = xmalloc(sdl->sdl_nlen + 1);
				memcpy(_iface, sdl->sdl_data, sdl->sdl_nlen);
				_iface[sdl->sdl_nlen + 1] = 0;
```
We can't write to `[sdl->sdl_nlen + 1] since this is one-past the array `xmalloc` gives us.

## Testing
### Before fix
On Mac, latest `main`
```shell
cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"; make -j 8; sudo ./src/zmap -p 80 171.67.71.209
...
==42559==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000000df4 at pc 0x0001006317f0 bp 0x00016f7d4790 sp 0x00016f7d4788
WRITE of size 1 at 0x602000000df4 thread T0                                                                                                                                          
    #0 0x0001006317ec in _get_default_gw get_gateway-bsd.h:192
    #1 0x000100631bf8 in get_default_iface get_gateway-bsd.h:213
    #2 0x00010064bed8 in network_config_init zmap.c:141
    #3 0x00010064b3d4 in main zmap.c:1002
    #4 0x000183781d50  (<unknown module>)

0x602000000df4 is located 0 bytes after 4-byte region [0x602000000df0,0x602000000df4)
allocated by thread T0 here:                                                                                                                                                         
    #0 0x0001011e1330 in malloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3d330)
    #1 0x0001006a02c4 in xmalloc xalloc.c:38
    #2 0x0001006316bc in _get_default_gw get_gateway-bsd.h:190
    #3 0x000100631bf8 in get_default_iface get_gateway-bsd.h:213
    #4 0x00010064bed8 in network_config_init zmap.c:141
    #5 0x00010064b3d4 in main zmap.c:1002
    #6 0x000183781d50  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow get_gateway-bsd.h:192 in _get_default_gw
Shadow bytes around the buggy address:
  0x602000000b00: fa fa 00 00 fa fa fd fd fa fa 00 00 fa fa fd fd
  0x602000000b80: fa fa 00 00 fa fa fd fd fa fa 00 00 fa fa fd fd
  0x602000000c00: fa fa 00 00 fa fa fd fd fa fa 00 00 fa fa fd fd
  0x602000000c80: fa fa 00 00 fa fa fd fd fa fa 00 00 fa fa fd fd
  0x602000000d00: fa fa 00 00 fa fa 00 00 fa fa fd fd fa fa 00 00
=>0x602000000d80: fa fa 00 fa fa fa fd fa fa fa 00 00 fa fa[04]fa
  0x602000000e00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x602000000e80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x602000000f00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x602000000f80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x602000001000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==42559==ABORTING
fish: Job 1, 'sudo ./src/zmap -p 80 171.67.71…' terminated by signal SIGABRT (Abort)
```

### After fix
```shell
cmake . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"; make -j 8; sudo ./src/zmap -p 80 171.67.71.209
 0:00 0%; send: 0 0 p/s (0 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%                                                                             
171.67.71.209
 0:01 13%; send: 1 done (816 p/s avg); recv: 1 1 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 100.00%
 0:02 25%; send: 1 done (816 p/s avg); recv: 1 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 100.00%
 0:03 38%; send: 1 done (816 p/s avg); recv: 1 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 100.00%
```