### PR TITLE
Adds a "blank" output field for easy multi-port scans with ZGrab2

### DIFF
--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -83,6 +83,7 @@ void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown, const 
 {
 	fs_add_bool(fs, "repeat", is_repeat);
 	fs_add_bool(fs, "cooldown", in_cooldown);
+	fs_add_null(fs, "blank");
 
 	char *timestr = xmalloc(TIMESTR_LEN + 1);
 	char *timestr_ms = xmalloc(TIMESTR_LEN + 1);
@@ -114,7 +115,7 @@ fielddef_t ip_fields[] = {
      .desc = "IP identification number of response"},
     {.name = "ttl", .type = "int", .desc = "time-to-live of response packet"}};
 
-int sys_fields_len = 5;
+int sys_fields_len = 6;
 fielddef_t sys_fields[] = {
     {.name = "repeat",
      .type = "bool",
@@ -122,6 +123,9 @@ fielddef_t sys_fields[] = {
     {.name = "cooldown",
      .type = "bool",
      .desc = "Was response received during the cooldown period"},
+    {.name = "blank",
+     .type = "null",
+     .desc = "inserts an empty column in CSV output; excluded from JSON output"},
     {.name = "timestamp_str",
      .type = "string",
      .desc = "timestamp of when response arrived in ISO8601 format."},


### PR DESCRIPTION
Per #960, it required writing some custom script to pipe multi-port ZMap scans into ZGrab2 (ex: scanning both ports 443 and 80 at once and piping into the `http` ZGrab2 module).

This PR adds a `blank` output field that can be used to insert a blank column in CSV output. It is ignored with JSON output.

Example
```shell
~/zmap-dev/zmap on  phillip/960-empty-output-field! ⌚ 22:22:19
$ sudo ./src/zmap -B 50M -N 10 --output-fields=saddr,blank,blank,sport --output-filter="success=1 && repeat=0 && classification!=icmp" -p 80,443 | awk -F ',' 'NR>1 && $4!=""'

 0:00 0%; send: 50 1 p/s (1.06 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
54.215.15.213,,,80
34.8.64.49,,,443
38.48.195.184,,,80
104.19.177.241,,,443
196.242.47.186,,,80
104.25.234.88,,,443
67.7.160.7,,,443
44.224.169.224,,,443
50.116.5.173,,,80
47.88.33.122,,,443
 0:01 13%; send: 7780 done (60.9 Kp/s avg); recv: 10 10 p/s (9 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.13%
May 07 22:22:24.601 [INFO] zmap: completed
```

(`awk` is used here to 1) discard the CSV headers in the first line and 2) ensure there is a port for each line. With `output-filter=classification!=icmp`, the `awk` for checking for port isn't required but you'll want one or the other. I'll update my [ZMap + ZGrab2 getting started guide](https://github.com/zmap/.github/blob/main/wiki/getting-started-with-zmap-and-zgrab2.md) with this once this PR is merged)

This fits with ZGrab2's input preference of `ip, domain, tag, port`.

## Testing

### CSV Output Module
```shell
~/zmap-dev/zmap on  phillip/960-empty-output-field! ⌚ 22:22:19
$ sudo ./src/zmap -B 50M -N 10 --output-fields=saddr,blank,blank,sport --output-filter="success=1 && repeat=0 && classification!=icmp" -p 80,443 | awk -F ',' 'NR>1 && $4!=""'

 0:00 0%; send: 50 1 p/s (1.06 Kp/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
54.215.15.213,,,80
34.8.64.49,,,443
38.48.195.184,,,80
104.19.177.241,,,443
196.242.47.186,,,80
104.25.234.88,,,443
67.7.160.7,,,443
44.224.169.224,,,443
50.116.5.173,,,80
47.88.33.122,,,443
 0:01 13%; send: 7780 done (60.9 Kp/s avg); recv: 10 10 p/s (9 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.13%
May 07 22:22:24.601 [INFO] zmap: completed
```

### JSON Output Module
Json output module ignores the `blank` output field if requested.
```shell
~/zmap-dev/zmap on  phillip/960-empty-output-field! ⌚ 22:31:44
$ sudo ./src/zmap -B 5M -N 10 --output-fields=saddr,blank,blank,sport --output-filter="success=1 && repeat=0 && classification!=icmp" -p 80,443 --output-module=json
...
 0:00 0%; send: 3 1 p/s (49 p/s avg); recv: 0 0 p/s (0 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.00%
{"saddr":"34.95.71.39","sport":80}
{"saddr":"44.235.219.98","sport":80}
{"saddr":"5.161.186.26","sport":443}
{"saddr":"3.128.238.128","sport":80}
{"saddr":"44.212.227.86","sport":443}
{"saddr":"184.29.115.142","sport":443}
{"saddr":"38.238.84.130","sport":80}
{"saddr":"44.236.180.207","sport":80}
{"saddr":"3.167.45.151","sport":443}
{"saddr":"92.207.209.175","sport":443}
 0:01 13%; send: 2284 done (6.89 Kp/s avg); recv: 10 10 p/s (9 p/s avg); drops: 0 p/s (0 p/s avg); hitrate: 0.44%
May 07 22:32:06.648 [INFO] zmap: completed
```

## Related Issues
Cloes #960 


