### PR TITLE
[tcp_synscan] add optional JA4TS fingerprint of SYN-ACK responses

### DIFF
--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -118,6 +118,7 @@ probe_module_t module_tcp_synscan;
 static uint16_t num_source_ports;
 static uint8_t os_for_tcp_options;
 static bool rtt_enabled = false;
+static bool ja4ts_enabled = false;
 
 // RTT is encoded in the lower RTT_TIMESTAMP_BITS of the TCP SYN sequence number
 // (XOR'd with validation[0]). The upper RTT_VALIDATION_BITS are used for packet
@@ -177,6 +178,8 @@ static int synscan_global_initialize(struct state_conf *state)
 	while (token) {
 		if (strcmp(token, "rtt") == 0) {
 			rtt_enabled = true;
+		} else if (strcmp(token, "ja4ts") == 0) {
+			ja4ts_enabled = true;
 		} else if (strcmp(token, "smallest-probes") == 0) {
 			if (os_set) {
 				log_fatal("tcp_synscan", "multiple OS options specified in probe-args");
@@ -213,9 +216,10 @@ static int synscan_global_initialize(struct state_conf *state)
 			log_fatal("tcp_synscan",
 				  "unknown probe-arg: \"%s\"; "
 				  "probe-args should be comma-separated and valid options are: "
-				  "an OS option (\"smallest-probes\", \"bsd\", \"linux\", \"windows\"(default)) "
-				  "and optionally \"rtt\" to enable RTT measurement. "
-				  "Examples: --probe-args=windows, --probe-args=rtt, --probe-args=linux,rtt",
+				  "an OS option (\"smallest-probes\", \"bsd\", \"linux\", \"windows\"(default)), "
+				  "optionally \"rtt\" to enable RTT measurement, "
+				  "and optionally \"ja4ts\" to emit the JA4TS TCP fingerprint. "
+				  "Examples: --probe-args=windows, --probe-args=rtt, --probe-args=linux,rtt, --probe-args=ja4ts",
 				  token);
 		}
 		token = strtok(NULL, ",");
@@ -227,16 +231,21 @@ static int synscan_global_initialize(struct state_conf *state)
 	// double-check arithmetic
 	assert(zmap_tcp_synscan_packet_len - zmap_tcp_synscan_tcp_header_len == 34);
 
-	// Warn if "rtt" was explicitly requested as an output field but not enabled via probe-args
-	if (!rtt_enabled && state->raw_output_fields &&
+	// Warn if "rtt" or "ja4ts" was explicitly requested as an output field but not enabled via probe-args
+	if (state->raw_output_fields &&
 	    strcmp(state->raw_output_fields, "*") != 0) {
 		for (int i = 0; i < state->output_fields_len; i++) {
-			if (strcmp(state->output_fields[i], "rtt") == 0) {
+			if (!rtt_enabled &&
+			    strcmp(state->output_fields[i], "rtt") == 0) {
 				log_warn("tcp_synscan",
 					 "\"rtt\" is listed in --output-fields but RTT is not enabled; "
-					 "add \"rtt\" to --probe-args to enable it "
-					 "(e.g. --probe-args=rtt or --probe-args=windows,rtt)");
-				break;
+					 "add \"rtt\" to --probe-args to enable it");
+			}
+			if (!ja4ts_enabled &&
+			    strcmp(state->output_fields[i], "ja4ts") == 0) {
+				log_warn("tcp_synscan",
+					 "\"ja4ts\" is listed in --output-fields but JA4TS is not enabled; "
+					 "add \"ja4ts\" to --probe-args to enable it");
 			}
 		}
 	}
@@ -561,6 +570,32 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		} else {
 			fs_add_null(fs, "rtt");
 		}
+		if (ja4ts_enabled) {
+			if (tcp->th_flags & TH_RST) {
+				fs_add_null(fs, "ja4ts");
+			} else {
+				char ja4ts_buf[256];
+				size_t header_size = tcp->th_off * 4;
+				size_t opts_len = header_size > 20
+					? header_size - 20
+					: 0;
+				const uint8_t *opts =
+				    (const uint8_t *)tcp + 20;
+				compute_ja4ts(opts, opts_len,
+					      ntohs(tcp->th_win), ja4ts_buf,
+					      sizeof(ja4ts_buf));
+				char *ja4ts_str = strdup(ja4ts_buf);
+				if (ja4ts_str) {
+					fs_add_string(fs, "ja4ts", ja4ts_str, 1);
+				} else {
+					log_warn("tcp_synscan",
+						 "failed to allocate memory for JA4TS string, adding null JA4TS field");
+					fs_add_null(fs, "ja4ts");
+				}
+			}
+		} else {
+			fs_add_null(fs, "ja4ts");
+		}
 	} else if (ip_hdr->ip_p == IPPROTO_ICMP) {
 		// tcp
 		fs_add_null(fs, "sport");
@@ -580,6 +615,7 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		fs_populate_icmp_from_iphdr(ip_hdr, len, fs);
 		// rtt
 		fs_add_null(fs, "rtt");
+		fs_add_null(fs, "ja4ts");
 	}
 }
 
@@ -597,6 +633,8 @@ static fielddef_t fields[] = {
     CLASSIFICATION_SUCCESS_FIELDSET_FIELDS,
     ICMP_FIELDSET_FIELDS,
     {.name = "rtt", .type = "string", .desc = "RTT in ms to one decimal place, max RTT reliably measured = ~28min"},
+    {.name = "ja4ts", .type = "string",
+     .desc = "JA4TS fingerprint of SYN-ACK: window_options_mss_wscale (see FoxIO JA4T)"},
 };
 
 probe_module_t module_tcp_synscan = {
@@ -623,8 +661,9 @@ probe_module_t module_tcp_synscan = {
 		"   - \"bsd\" (MSS + NOP + WindowScale=6 + Timestamps + SACK)\n"
 		"   - \"smallest-probes\" (MSS only, fits minimum Ethernet payload, gives a better hitrate than no options while retaining the same send performance)\n"
 	        " 2. Add \"rtt\" to enable RTT measurement to reports RTT in ms to 0.1 ms granularity (max ~28 min RTT).\n"
+		" 3. Add \"ja4ts\" to emit the JA4TS TCP fingerprint of the SYN-ACK.\n"
 	"Examples: --probe-args=windows, --probe-args=rtt (windows + RTT), "
-	"--probe-args=linux,rtt. RTT works best with --batch 1. ",
+	"--probe-args=linux,rtt, --probe-args=ja4ts. RTT works best with --batch 1. ",
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
     .numfields = sizeof(fields) / sizeof(fields[0])};

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -237,28 +237,51 @@ static int synscan_global_initialize(struct state_conf *state)
 	assert(zmap_tcp_synscan_packet_len - zmap_tcp_synscan_tcp_header_len == 34);
 
 	// Warn if "rtt" or "ja4ts" was explicitly requested as an output field but not enabled via probe-args
+	bool rtt_output_requested = false;
+	bool ja4ts_output_requested = false;
+	bool ja4t_output_requested = false;
 	if (state->raw_output_fields &&
 	    strcmp(state->raw_output_fields, "*") != 0) {
 		for (int i = 0; i < state->output_fields_len; i++) {
-			if (!rtt_enabled &&
-			    strcmp(state->output_fields[i], "rtt") == 0) {
-				log_warn("tcp_synscan",
-					 "\"rtt\" is listed in --output-fields but RTT is not enabled; "
-					 "add \"rtt\" to --probe-args to enable it");
+			if (strcmp(state->output_fields[i], "rtt") == 0) {
+				rtt_output_requested = true;
+				if (!rtt_enabled) {
+					log_warn("tcp_synscan",
+						 "\"rtt\" is listed in --output-fields but RTT is not enabled; "
+						 "add \"rtt\" to --probe-args to enable it");
+				}
 			}
-			if (!ja4ts_enabled &&
-			    strcmp(state->output_fields[i], "ja4ts") == 0) {
-				log_warn("tcp_synscan",
-					 "\"ja4ts\" is listed in --output-fields but JA4TS is not enabled; "
-					 "add \"ja4ts\" to --probe-args to enable it");
+			if (strcmp(state->output_fields[i], "ja4ts") == 0) {
+				ja4ts_output_requested = true;
+			    	if (!ja4ts_enabled) {
+			    		log_warn("tcp_synscan",
+						     "\"ja4ts\" is listed in --output-fields but JA4TS is not enabled; "
+						     "add \"ja4ts\" to --probe-args to enable it");
+			    	}
 			}
-			if (!ja4t_enabled &&
-			    strcmp(state->output_fields[i], "ja4t") == 0) {
-				log_warn("tcp_synscan",
-					 "\"ja4t\" is listed in --output-fields but JA4T is not enabled; "
-					 "add \"ja4t\" to --probe-args to enable it");
+			if ( strcmp(state->output_fields[i], "ja4t") == 0) {
+				ja4t_output_requested = true;
+				if (!ja4t_enabled) {
+					log_warn("tcp_synscan",
+						 "\"ja4t\" is listed in --output-fields but JA4T is not enabled; "
+						 "add \"ja4t\" to --probe-args to enable it");
+				}
 			}
 		}
+	} else if (state->raw_output_fields && strcmp(state->raw_output_fields, "*") == 0) {
+		// All output fields requested
+		rtt_output_requested = true;
+		ja4ts_output_requested = true;
+		ja4t_output_requested = true;
+	}
+	if (rtt_enabled && !rtt_output_requested) {
+		log_warn("tcp_synscan", "RTT measurement enabled through --probe-args but not requested in --output-fields. You may want to add --output-fields=\"...,rtt\"");
+	}
+	if (ja4ts_enabled && !ja4ts_output_requested) {
+		log_warn("tcp_synscan", "JA4TS enabled through --probe-args but not requested in --output-fields. You may want to add --output-fields=\"...,ja4ts\"");
+	}
+	if (ja4t_enabled && !ja4t_output_requested) {
+		log_warn("tcp_synscan", "JA4T enabled through --probe-args but not requested in --output-fields. You may want to add --output-fields=\"...,ja4t\"");
 	}
 
 	if (rtt_enabled) {

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -119,6 +119,8 @@ static uint16_t num_source_ports;
 static uint8_t os_for_tcp_options;
 static bool rtt_enabled = false;
 static bool ja4ts_enabled = false;
+static bool ja4t_enabled = false;
+static char ja4t_buf[256];
 
 // RTT is encoded in the lower RTT_TIMESTAMP_BITS of the TCP SYN sequence number
 // (XOR'd with validation[0]). The upper RTT_VALIDATION_BITS are used for packet
@@ -180,6 +182,8 @@ static int synscan_global_initialize(struct state_conf *state)
 			rtt_enabled = true;
 		} else if (strcmp(token, "ja4ts") == 0) {
 			ja4ts_enabled = true;
+		} else if (strcmp(token, "ja4t") == 0) {
+			ja4t_enabled = true;
 		} else if (strcmp(token, "smallest-probes") == 0) {
 			if (os_set) {
 				log_fatal("tcp_synscan", "multiple OS options specified in probe-args");
@@ -218,8 +222,9 @@ static int synscan_global_initialize(struct state_conf *state)
 				  "probe-args should be comma-separated and valid options are: "
 				  "an OS option (\"smallest-probes\", \"bsd\", \"linux\", \"windows\"(default)), "
 				  "optionally \"rtt\" to enable RTT measurement, "
-				  "and optionally \"ja4ts\" to emit the JA4TS TCP fingerprint. "
-				  "Examples: --probe-args=windows, --probe-args=rtt, --probe-args=linux,rtt, --probe-args=ja4ts",
+				  "optionally \"ja4ts\" to emit the JA4TS fingerprint of the SYN-ACK, "
+				  "and optionally \"ja4t\" to emit the JA4T fingerprint of zmap's own SYN. "
+				  "Examples: --probe-args=windows, --probe-args=rtt, --probe-args=linux,rtt, --probe-args=ja4ts,ja4t",
 				  token);
 		}
 		token = strtok(NULL, ",");
@@ -246,6 +251,12 @@ static int synscan_global_initialize(struct state_conf *state)
 				log_warn("tcp_synscan",
 					 "\"ja4ts\" is listed in --output-fields but JA4TS is not enabled; "
 					 "add \"ja4ts\" to --probe-args to enable it");
+			}
+			if (!ja4t_enabled &&
+			    strcmp(state->output_fields[i], "ja4t") == 0) {
+				log_warn("tcp_synscan",
+					 "\"ja4t\" is listed in --output-fields but JA4T is not enabled; "
+					 "add \"ja4t\" to --probe-args to enable it");
 			}
 		}
 	}
@@ -277,6 +288,14 @@ static int synscan_prepare_packet(void *buf, macaddr_t *src, macaddr_t *gw,
 	struct tcphdr *tcp_header = (struct tcphdr *)(&ip_header[1]);
 	make_tcp_header(tcp_header, TH_SYN);
 	set_tcp_options(tcp_header, os_for_tcp_options);
+	if (ja4t_enabled) {
+		size_t opts_len = zmap_tcp_synscan_tcp_header_len > 20
+			? zmap_tcp_synscan_tcp_header_len - 20
+			: 0;
+		const uint8_t *opts = (const uint8_t *)tcp_header + 20;
+		compute_ja4ts(opts, opts_len, ntohs(tcp_header->th_win),
+			      ja4t_buf, sizeof(ja4t_buf));
+	}
 	return EXIT_SUCCESS;
 }
 
@@ -596,6 +615,18 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		} else {
 			fs_add_null(fs, "ja4ts");
 		}
+		if (ja4t_enabled) {
+			char *ja4t_str = strdup(ja4t_buf);
+			if (ja4t_str) {
+				fs_add_string(fs, "ja4t", ja4t_str, 1);
+			} else {
+				log_warn("tcp_synscan",
+					 "failed to allocate memory for JA4T string, adding null JA4T field");
+				fs_add_null(fs, "ja4t");
+			}
+		} else {
+			fs_add_null(fs, "ja4t");
+		}
 	} else if (ip_hdr->ip_p == IPPROTO_ICMP) {
 		// tcp
 		fs_add_null(fs, "sport");
@@ -616,6 +647,7 @@ static void synscan_process_packet(const u_char *packet, UNUSED uint32_t len,
 		// rtt
 		fs_add_null(fs, "rtt");
 		fs_add_null(fs, "ja4ts");
+		fs_add_null(fs, "ja4t");
 	}
 }
 
@@ -635,6 +667,8 @@ static fielddef_t fields[] = {
     {.name = "rtt", .type = "string", .desc = "RTT in ms to one decimal place, max RTT reliably measured = ~28min"},
     {.name = "ja4ts", .type = "string",
      .desc = "JA4TS fingerprint of SYN-ACK: window_options_mss_wscale (see FoxIO JA4T)"},
+    {.name = "ja4t", .type = "string",
+     .desc = "JA4T fingerprint of zmap's own SYN: window_options_mss_wscale (see FoxIO JA4T); constant per scan"},
 };
 
 probe_module_t module_tcp_synscan = {
@@ -662,8 +696,9 @@ probe_module_t module_tcp_synscan = {
 		"   - \"smallest-probes\" (MSS only, fits minimum Ethernet payload, gives a better hitrate than no options while retaining the same send performance)\n"
 	        " 2. Add \"rtt\" to enable RTT measurement to reports RTT in ms to 0.1 ms granularity (max ~28 min RTT).\n"
 		" 3. Add \"ja4ts\" to emit the JA4TS TCP fingerprint of the SYN-ACK.\n"
+		" 4. Add \"ja4t\" to emit the JA4T TCP fingerprint of zmap's own SYN (constant per scan).\n"
 	"Examples: --probe-args=windows, --probe-args=rtt (windows + RTT), "
-	"--probe-args=linux,rtt, --probe-args=ja4ts. RTT works best with --batch 1. ",
+	"--probe-args=linux,rtt, --probe-args=ja4ts,ja4t. RTT works best with --batch 1. ",
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
     .numfields = sizeof(fields) / sizeof(fields[0])};

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -12,9 +12,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+
+#ifndef JA4TS_UNIT_TEST
 #include <unistd.h>
 #include <time.h>
-#include <string.h>
 #include <assert.h>
 #include <math.h>
 #include <errno.h>
@@ -27,6 +30,82 @@
 #include "probe_modules.h"
 #include "packet.h"
 #include "validate.h"
+#endif /* !JA4TS_UNIT_TEST */
+
+#define JA4TS_OPT_EOL    0
+#define JA4TS_OPT_NOP    1
+#define JA4TS_OPT_MSS    2
+#define JA4TS_OPT_WSCALE 3
+
+void compute_ja4ts(const uint8_t *opts, size_t opts_len, uint16_t window,
+		   char *out, size_t out_len)
+{
+	if (!opts) {
+		opts_len = 0;
+	}
+
+	/* TCP options region <= 40 bytes; worst case ~40 kinds * 4 chars ("xxx-") < 200. */
+	char kinds[200];
+	size_t kinds_off = 0;
+	kinds[0] = '\0';
+
+	int have_mss = 0;
+	uint16_t mss_val = 0;
+	int have_wscale = 0;
+	uint8_t wscale_val = 0;
+
+	size_t i = 0;
+	while (i < opts_len) {
+		uint8_t kind = opts[i];
+
+		int n = snprintf(kinds + kinds_off, sizeof(kinds) - kinds_off,
+				 kinds_off == 0 ? "%u" : "-%u", kind);
+		if (n <= 0 || (size_t)n >= sizeof(kinds) - kinds_off) {
+			break;
+		}
+		kinds_off += (size_t)n;
+
+		if (kind == JA4TS_OPT_EOL) {
+			break;
+		}
+		if (kind == JA4TS_OPT_NOP) {
+			i += 1;
+			continue;
+		}
+
+		if (i + 1 >= opts_len) {
+			break;
+		}
+		uint8_t len = opts[i + 1];
+		if (len < 2 || i + len > opts_len) {
+			break;
+		}
+
+		if (kind == JA4TS_OPT_MSS && len == 4 && !have_mss) {
+			mss_val = (uint16_t)(((uint16_t)opts[i + 2] << 8) | opts[i + 3]);
+			have_mss = 1;
+		} else if (kind == JA4TS_OPT_WSCALE && len == 3 && !have_wscale) {
+			wscale_val = opts[i + 2];
+			have_wscale = 1;
+		}
+
+		i += len;
+	}
+
+	if (have_mss && have_wscale) {
+		snprintf(out, out_len, "%u_%s_%u_%u", window, kinds, mss_val,
+			 wscale_val);
+	} else if (have_mss) {
+		snprintf(out, out_len, "%u_%s_%u_00", window, kinds, mss_val);
+	} else if (have_wscale) {
+		snprintf(out, out_len, "%u_%s_00_%u", window, kinds,
+			 wscale_val);
+	} else {
+		snprintf(out, out_len, "%u_%s_00_00", window, kinds);
+	}
+}
+
+#ifndef JA4TS_UNIT_TEST
 
 // defaults
 static uint8_t zmap_tcp_synscan_tcp_header_len = 20;
@@ -549,3 +628,5 @@ probe_module_t module_tcp_synscan = {
     .output_type = OUTPUT_TYPE_STATIC,
     .fields = fields,
     .numfields = sizeof(fields) / sizeof(fields[0])};
+
+#endif /* !JA4TS_UNIT_TEST */

--- a/src/probe_modules/module_tcp_synscan.h
+++ b/src/probe_modules/module_tcp_synscan.h
@@ -8,21 +8,43 @@
 
 // probe module for performing TCP SYN scans
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <unistd.h>
 #include <string.h>
+
+#ifndef JA4TS_UNIT_TEST
+#include <unistd.h>
 #include <assert.h>
 
 #include "../../lib/includes.h"
 #include "../fieldset.h"
 #include "probe_modules.h"
 #include "packet.h"
+#endif /* !JA4TS_UNIT_TEST */
 
 #define SMALLEST_PROBES_OS_OPTIONS 0x00
 #define LINUX_OS_OPTIONS 0x01
 #define BSD_OS_OPTIONS 0x02
 #define WINDOWS_OS_OPTIONS 0x03
 
+#ifndef JA4TS_UNIT_TEST
 void synscan_print_packet(FILE *fp, void *packet);
+#endif /* !JA4TS_UNIT_TEST */
+
+/* Format a JA4TS string for a SYN-ACK.
+ *
+ *   opts:        pointer to TCP options bytes (i.e. (uint8_t*)tcp + 20)
+ *   opts_len:    length of the options region in bytes (data_offset*4 - 20)
+ *   window:      TCP receive window, host byte order
+ *   out:         caller-provided buffer
+ *   out_len:     size of out in bytes (>= 256 recommended)
+ *
+ * Always writes a NUL-terminated string. Stops parsing on the first
+ * malformed option and emits whatever was collected up to that point.
+ * "00" is emitted for MSS / wscale when the corresponding option is
+ * absent; "0" is emitted when the option is present with value 0.
+ */
+void compute_ja4ts(const uint8_t *opts, size_t opts_len, uint16_t window,
+		   char *out, size_t out_len);

--- a/test/integration-tests/test_ja4ts.py
+++ b/test/integration-tests/test_ja4ts.py
@@ -1,0 +1,48 @@
+import os
+import re
+
+import zmap_wrapper
+
+
+OUTPUT = "ja4ts_output.txt"
+JA4TS_RE = re.compile(r"^[0-9]+_[0-9-]*_[0-9]+_[0-9]+$")
+
+
+def test_ja4ts_field_well_formed():
+    """
+    Scan known-active DNS resolvers on port 53 with --probe-args=ja4ts and
+    verify that each SYN-ACK row carries a well-formed ja4ts fingerprint.
+    """
+    targets = ["1.1.1.1", "8.8.8.8"]
+    with open(OUTPUT, "w") as f:
+        f.write("")
+    t = zmap_wrapper.Wrapper(
+        dryrun=False,
+        port=53,
+        subnet=" ".join(targets),
+        threads=1,
+        output_file=OUTPUT,
+        max_cooldown=3,
+        probe_args="ja4ts",
+        output_fields="saddr,ja4ts,classification",
+    )
+    t.run()
+    saw_synack = False
+    try:
+        with open(OUTPUT) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("saddr"):
+                    continue
+                parts = line.split(",")
+                assert len(parts) == 3, f"unexpected line shape: {line!r}"
+                saddr, ja4ts, cls = parts
+                if cls != "synack":
+                    continue
+                saw_synack = True
+                assert JA4TS_RE.match(ja4ts), (
+                    f"malformed ja4ts for {saddr}: {ja4ts!r}"
+                )
+        assert saw_synack, "no SYN-ACK responses observed; cannot validate ja4ts"
+    finally:
+        os.remove(OUTPUT)

--- a/test/integration-tests/zmap_wrapper.py
+++ b/test/integration-tests/zmap_wrapper.py
@@ -8,7 +8,8 @@ PACKET_SEP = "-" * 54
 class Wrapper:
     def __init__(self, port="80", subnet="", num_of_ips=-1, threads=-1, shards=-1, shard=-1, seed=-1, iplayer=False,
                  dryrun=True, output_file="", max_runtime=-1, max_cooldown=-1, blocklist_file="", allowlist_file="",
-                 list_of_ips_file="", probes="", source_ip="", source_port="", source_mac="", rate=-1, max_targets=""):
+                 list_of_ips_file="", probes="", source_ip="", source_port="", source_mac="", rate=-1, max_targets="",
+                 probe_args="", output_fields=""):
         self.port = port
         self.subnet = subnet
         self.num_of_ips = num_of_ips
@@ -30,6 +31,8 @@ class Wrapper:
         self.source_mac = source_mac
         self.rate = rate
         self.max_targets = max_targets
+        self.probe_args = probe_args
+        self.output_fields = output_fields
 
 
     def run(self):
@@ -75,6 +78,10 @@ class Wrapper:
             args.extend(["--rate=" + str(self.rate)])
         if self.max_targets != "":
             args.extend(["--max-targets=" + str(self.max_targets)])
+        if self.probe_args:
+            args.extend(["--probe-args=" + self.probe_args])
+        if self.output_fields:
+            args.extend(["-f", self.output_fields])
 
         test_output = subprocess.run(args, stdout=subprocess.PIPE).stdout.decode('utf-8')
         packets = parse_output_into_obj_list(test_output)

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,0 +1,17 @@
+# Standalone unit-test build for ja4ts formatter.
+# Usage: make -C test/unit run
+
+CC      ?= cc
+CFLAGS  ?= -Wall -Wextra -std=c99 -g -O0
+SRCDIR  := ../../src
+
+test_ja4ts: test_ja4ts.c $(SRCDIR)/probe_modules/module_tcp_synscan.c $(SRCDIR)/probe_modules/module_tcp_synscan.h
+	$(CC) $(CFLAGS) -I$(SRCDIR) -DJA4TS_UNIT_TEST test_ja4ts.c -o test_ja4ts
+
+run: test_ja4ts
+	./test_ja4ts
+
+clean:
+	rm -f test_ja4ts
+
+.PHONY: run clean

--- a/test/unit/test_ja4ts.c
+++ b/test/unit/test_ja4ts.c
@@ -83,6 +83,69 @@ static void test_eol_stops(void)
 	expect_eq_str("64240_2-0_1460_00", out, "eol_stops");
 }
 
+/* JA4T tests: verify compute_ja4ts against the exact byte sequences that
+ * set_tcp_options() emits for each OS profile (window is always 65535). */
+
+static void test_ja4t_smallest_probes(void)
+{
+	/* set_mss_option only: kind=2, len=4, MSS=1460 */
+	uint8_t opts[] = {0x02, 0x04, 0x05, 0xb4};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	expect_eq_str("65535_2_1460_00", out, "ja4t_smallest_probes");
+}
+
+static void test_ja4t_windows(void)
+{
+	/* set_mss_option + set_nop_plus_windows_scale(WINDOWS) + set_nop_plus_sack_permitted */
+	uint8_t opts[] = {
+		0x02, 0x04, 0x05, 0xb4,  /* MSS 1460 */
+		0x01,                    /* NOP */
+		0x03, 0x03, 0x08,        /* WScale 8 */
+		0x01,                    /* NOP */
+		0x01,                    /* NOP */
+		0x04, 0x02,              /* SACK-perm */
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	expect_eq_str("65535_2-1-3-1-1-4_1460_8", out, "ja4t_windows");
+}
+
+static void test_ja4t_linux(void)
+{
+	/* set_mss_option + set_sack_permitted_with_timestamp + set_nop_plus_windows_scale(LINUX) */
+	uint8_t opts[] = {
+		0x02, 0x04, 0x05, 0xb4,           /* MSS 1460 */
+		0x04, 0x02,                       /* SACK-perm */
+		0x08, 0x0a, 0,0,0,0, 0,0,0,0,     /* Timestamps (value irrelevant to fingerprint) */
+		0x01,                             /* NOP */
+		0x03, 0x03, 0x07,                 /* WScale 7 */
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	expect_eq_str("65535_2-4-8-1-3_1460_7", out, "ja4t_linux");
+}
+
+static void test_ja4t_bsd(void)
+{
+	/* set_mss_option + set_nop_plus_windows_scale(BSD) + set_timestamp_option_with_nops
+	 * + set_sack_permitted_plus_eol */
+	uint8_t opts[] = {
+		0x02, 0x04, 0x05, 0xb4,           /* MSS 1460 */
+		0x01,                             /* NOP */
+		0x03, 0x03, 0x06,                 /* WScale 6 */
+		0x01,                             /* NOP */
+		0x01,                             /* NOP */
+		0x08, 0x0a, 0,0,0,0, 0,0,0,0,     /* Timestamps */
+		0x04, 0x02,                       /* SACK-perm */
+		0x00,                             /* EOL */
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	/* EOL (kind 0) is recorded before the break, so it appears in the kinds list */
+	expect_eq_str("65535_2-1-3-1-1-8-4-0_1460_6", out, "ja4t_bsd");
+}
+
 int main(void)
 {
 	test_no_options();
@@ -91,6 +154,11 @@ int main(void)
 	test_wscale_zero();
 	test_malformed_length();
 	test_eol_stops();
+
+	test_ja4t_smallest_probes();
+	test_ja4t_windows();
+	test_ja4t_linux();
+	test_ja4t_bsd();
 
 	return failures == 0 ? 0 : 1;
 }

--- a/test/unit/test_ja4ts.c
+++ b/test/unit/test_ja4ts.c
@@ -1,0 +1,96 @@
+#define JA4TS_UNIT_TEST 1
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "probe_modules/module_tcp_synscan.h"
+#include "probe_modules/module_tcp_synscan.c"
+
+static int failures = 0;
+
+static void expect_eq_str(const char *expected, const char *actual,
+			  const char *label)
+{
+	if (strcmp(actual, expected) != 0) {
+		fprintf(stderr, "FAIL %s: expected \"%s\", got \"%s\"\n",
+			label, expected, actual);
+		failures++;
+	} else {
+		fprintf(stdout, "PASS %s\n", label);
+	}
+}
+
+static void test_no_options(void)
+{
+	char out[256];
+	compute_ja4ts(NULL, 0, 64240, out, sizeof(out));
+	expect_eq_str("64240__00_00", out, "no_options");
+}
+
+static void test_mss_only(void)
+{
+	uint8_t opts[] = {0x02, 0x04, 0x05, 0xb4};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	expect_eq_str("65535_2_1460_00", out, "mss_only");
+}
+
+static void test_linux_like(void)
+{
+	uint8_t opts[] = {
+		0x02, 0x04, 0x05, 0xb4,           /* MSS 1460 */
+		0x04, 0x02,                       /* SACK-perm */
+		0x08, 0x0a, 0,0,0,0, 0,0,0,0,     /* Timestamps */
+		0x01,                             /* NOP */
+		0x03, 0x03, 0x07,                 /* WScale 7 */
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 65535, out, sizeof(out));
+	expect_eq_str("65535_2-4-8-1-3_1460_7", out, "linux_like");
+}
+
+static void test_wscale_zero(void)
+{
+	uint8_t opts[] = {0x03, 0x03, 0x00};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 8192, out, sizeof(out));
+	expect_eq_str("8192_3_00_0", out, "wscale_zero");
+}
+
+static void test_malformed_length(void)
+{
+	uint8_t opts[] = {
+		0x01,             /* NOP */
+		0x02, 99,         /* MSS with bogus length */
+		0x02, 0x04, 0x05, 0xb4,
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 1000, out, sizeof(out));
+	expect_eq_str("1000_1-2_00_00", out, "malformed_length");
+}
+
+static void test_eol_stops(void)
+{
+	uint8_t opts[] = {
+		0x02, 0x04, 0x05, 0xb4,
+		0x00,                   /* EOL */
+		0x03, 0x03, 0x07,       /* not reached */
+	};
+	char out[256];
+	compute_ja4ts(opts, sizeof(opts), 64240, out, sizeof(out));
+	/* EOL kind (0) appears in kinds list because the kind is recorded before the EOL break. */
+	expect_eq_str("64240_2-0_1460_00", out, "eol_stops");
+}
+
+int main(void)
+{
+	test_no_options();
+	test_mss_only();
+	test_linux_like();
+	test_wscale_zero();
+	test_malformed_length();
+	test_eol_stops();
+
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds opt-in JA4TS TCP fingerprinting to the `tcp_synscan` probe module. Pass `--probe-args=ja4ts` to emit a new `ja4ts` output field containing the FoxIO JA4TS fingerprint of each SYN-ACK response.

Format: `{window}_{tcp_option_kinds_in_order}_{mss}_{wscale_shift}` (decimal, dash-separated kinds, `00` sentinel for absent MSS/wscale). See https://medium.com/foxio/ja4t-tcp-fingerprinting-12fb7ce9cb5a for the fingerprint definition.

Combines with other probe-args: `--probe-args=windows,ja4ts`, `--probe-args=linux,rtt,ja4ts`, etc.

Example:

```
$ sudo zmap -p 53 --probe-args=windows,ja4ts -f saddr,ja4ts,classification 1.1.1.1 8.8.8.8
1.1.1.1,65535_2-4-8-1-3_1460_7,synack
8.8.8.8,65535_2-4-8-1-3_1460_7,synack
```

## Implementation

- Pure formatter `compute_ja4ts()` walks TCP options once, preserves option-kind order (including NOPs and EOL), captures raw MSS and wscale shift, and writes the JA4TS string.
- Gated behind a new `ja4ts` token in `--probe-args`, paralleling the existing `rtt` token. New `ja4ts` field is null for RST and ICMP responses, or when the feature isn't enabled.
- Warns if `ja4ts` appears in `--output-fields` but isn't enabled via `--probe-args`, matching the existing `rtt` behavior.
- `tcp_synackscan` is unchanged — JA4TS is a SYN-ACK fingerprint and has no application there.

## Tests

- **Unit tests** under `test/unit/` (built standalone via `make -C test/unit run`). Six cases cover: no options, MSS-only, Linux-like full options, wscale shift 0 (distinct from absent), malformed length (defensive stop), and EOL termination.
- **Integration test** under `test/integration-tests/test_ja4ts.py` runs `zmap --probe-args=ja4ts` against `1.1.1.1` / `8.8.8.8` and asserts the field is well-formed.
