### PR TITLE
WIP: Add Judy1 cacheset for dedup on 64-bit machines

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(LIB_SOURCES
     blocklist.c
     cachehash.c
+    cacheset.c
     constraint.c
     logger.c
     pbm.c

--- a/lib/cacheset.c
+++ b/lib/cacheset.c
@@ -1,0 +1,84 @@
+/*
+ * CacheSet Copyright 2026 Jakob Wiesmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+#include "cacheset.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+
+#include <Judy.h>
+
+struct cacheset_s {
+	Pvoid_t judy;
+	uint64_t *ring;
+	size_t maxsize;
+	size_t currsize;
+	size_t head;
+};
+
+cacheset *cacheset_init(size_t maxitems)
+{
+	assert(maxitems > 0);
+	cacheset *retv = malloc(sizeof(cacheset));
+	assert(retv);
+	memset(retv, 0, sizeof(cacheset));
+	retv->ring = calloc(maxitems, sizeof(uint64_t));
+	assert(retv->ring);
+	retv->maxsize = maxitems;
+	retv->currsize = 0;
+	retv->head = 0;
+	retv->judy = NULL;
+
+	return retv;
+}
+
+int cacheset_check(cacheset *cs, uint64_t key)
+{
+	assert(cs);
+	int rc;
+	J1T(rc, cs->judy, key);
+
+	return rc;
+}
+
+int cacheset_add(cacheset *cs, uint64_t key)
+{
+	assert(cs);
+	int rc;
+	J1T(rc, cs->judy, key); // check if key already in set
+	if (rc == 1) {
+		return 1;
+	}
+
+	// check if set is full, if so replace the oldest entry
+	if (cs->currsize == cs->maxsize) {
+		uint64_t old_key = cs->ring[cs->head];
+		J1U(rc, cs->judy, old_key);
+		assert(rc == 1);
+		cs->currsize--;
+	}
+
+	J1S(rc, cs->judy, key);
+	assert(rc == 1);
+	cs->ring[cs->head] = key;
+	cs->head = (cs->head + 1) % cs->maxsize;
+	cs->currsize++;
+
+	return 0;
+}
+
+void cacheset_free(cacheset *cs)
+{
+	assert(cs);
+	Word_t rc;
+	J1FA(rc, cs->judy);
+	free(cs->ring);
+	free(cs);
+}

--- a/lib/cacheset.h
+++ b/lib/cacheset.h
@@ -1,0 +1,41 @@
+/*
+ * CacheSet Copyright 2026 Jakob Wiesmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef CACHESET_H
+#define CACHESET_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct cacheset_s cacheset;
+
+// initialize new cache set with a maximum capacity.
+// returns NULL on alloc failure.
+cacheset *cacheset_init(size_t maxitems);
+
+// test whether a given key is in the cache.
+// return 1 if present and 0 if not.
+int cacheset_check(cacheset *cs, uint64_t key);
+
+// insert a key into the set.
+// if the cache is full, the oldest entry is evicted.
+// returns 0 if the key was newly inserted, or 1 if the key was already present.
+int cacheset_add(cacheset *cs, uint64_t key);
+
+// free memory used by cacheset
+void cacheset_free(cacheset *cs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/recv.c
+++ b/src/recv.c
@@ -11,7 +11,6 @@
 #include <assert.h>
 
 #include "../lib/includes.h"
-#include "cachehash.h"
 #include "../lib/util.h"
 #include "../lib/logger.h"
 #include "../lib/pbm.h"
@@ -29,10 +28,26 @@
 #include "probe_modules/probe_modules.h"
 #include "output_modules/output_modules.h"
 
+// Judy1 keys are word sized. On 32 bit systems ip+port dedup key does not fit.
+// Therefore use cacheset (Judy1) only on 64-bit where the word can hold the full key.
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__LP64__) || defined(_LP64)
+#define SYSTEM_64
+#endif
+
+#ifdef SYSTEM_64
+#include "../lib/cacheset.h"
+#else
+#include "cachehash.h"
+#endif
+
 static u_char fake_eth_hdr[65535];
 // bitmap of observed IP addresses
 static uint8_t **seen = NULL;
+#ifdef SYSTEM_64
+static cacheset *cs = NULL;
+#else
 static cachehash *ch = NULL;
+#endif
 
 void handle_packet(uint32_t buflen, const u_char *bytes,
 		   const struct timespec ts)
@@ -80,12 +95,19 @@ void handle_packet(uint32_t buflen, const u_char *bytes,
 	if (zconf.dedup_method == DEDUP_METHOD_FULL) {
 		is_repeat = pbm_check(seen, ntohl(src_ip));
 	} else if (zconf.dedup_method == DEDUP_METHOD_WINDOW) {
+#ifdef SYSTEM_64
+		uint64_t dedup_key =  ((uint64_t)src_ip << 16) | (uint64_t)src_port;
+		if (cacheset_add(cs, dedup_key)) {
+			is_repeat = 1;
+		}
+#else
 		target_t t = {.ip = src_ip, .port = src_port, .status = 0};
 		if (cachehash_get(ch, &t, sizeof(target_t))) {
 			is_repeat = 1;
 		} else {
 			cachehash_put(ch, &t, sizeof(target_t), (void *)1);
 		}
+#endif
 	}
 	// track whether this is the first packet in an IP fragment.
 	if (ip_hdr->ip_off & IP_MF) {
@@ -189,7 +211,11 @@ int recv_run(pthread_mutex_t *recv_ready_mutex)
 	if (zconf.dedup_method == DEDUP_METHOD_FULL) {
 		seen = pbm_init();
 	} else if (zconf.dedup_method == DEDUP_METHOD_WINDOW) {
+#ifdef SYSTEM_64
+		cs = cacheset_init(zconf.dedup_window_size);
+#else
 		ch = cachehash_init(zconf.dedup_window_size, NULL);
+#endif
 	}
 	if (zconf.default_mode) {
 		log_info("recv",
@@ -231,6 +257,15 @@ int recv_run(pthread_mutex_t *recv_ready_mutex)
 		pthread_mutex_lock(recv_ready_mutex);
 		recv_cleanup();
 		pthread_mutex_unlock(recv_ready_mutex);
+	}
+	if (zconf.dedup_method == DEDUP_METHOD_WINDOW) {
+#ifdef SYSTEM_64
+		cacheset_free(cs);
+		cs = NULL;
+#else
+		cachehash_free(ch, NULL);
+		ch = NULL;
+#endif
 	}
 	zrecv.complete = 1;
 	log_debug("recv", "thread finished");


### PR DESCRIPTION
Closes #849 

## Summary
Adds cacheset, which is a data structure with a Judy1 backend. It can be used for deduplication on 64-bit systems. On 32-bit systems, the existing cachehash is still being used because the needed data does not fit in 32 bits.

## Motivation
See #849 for motivation.

## Design Decisions
The current [cachehash](https://github.com/zmap/zmap/blob/main/lib/cachehash.h) implementation implements an LRU cache by using JudyHS. It maps each key to a node_t pointer. node_t is a doubly linked list which maintains recency order. This way an LRU cache can be easily implemented. 
To implement this with Judy1 we run into the following problem: Judy1 has no connection between the key and the value. Therefore implementing the LRU strategy isn't straightforward. 
This implementation uses FIFO eviction instead. Thus, for me, the question arises: is this fine in this scenario?
